### PR TITLE
Fix broadcasting of PHIS in state adjustments

### DIFF
--- a/hiccup_state_adjustment.py
+++ b/hiccup_state_adjustment.py
@@ -203,15 +203,16 @@ def adjust_surface_pressure( ds_data, ds_topo, pressure_var_name='plev',
   del_phis.load()
 
   # Calculate new surface pressure                                               pg 9 eq 12
+  *__, del_phis = xr.broadcast(ds_data['PS'], del_phis)
   beta = del_phis/(Rdair*Tstar)
   temp = beta*(1. - 0.5*alpha*beta + (1./3.)*(alpha*beta)**2. )
-  ps_new = ds_data['PS'].values * np.exp( temp.values )
+  ps_new = ds_data['PS'] * np.exp( temp )
 
   # save attributes to restore later
   ps_attrs = ds_data['PS'].attrs
 
   # Only update PHIS if phis difference is not negligible
-  ds_data['PS'].values = xr.where( np.abs(del_phis) > phis_threshold, ps_new, ds_data['PS'].values )
+  ds_data['PS'] = xr.where( np.abs(del_phis) > phis_threshold, ps_new, ds_data['PS'])
 
   # restore attributes
   ds_data['PS'].attrs = ps_attrs


### PR DESCRIPTION
Fix broadcasting of PHIS in state adjustment routines. An issue arises
when PHIS has shape (ncol), but PS has shape (ntime, ncol). In this
case, the broadcasting of computed arrays depends on the order in which
these arrays appear in computations. So if PS appears first, then
computed arrays will have shape (ntime, ncol), but if PHIS appears
first, computed arrays will have shape (ncol, ntime). The if the values
attributed is used to explicitly access the underlying data, we can get
mismatched shapes that end up with numpy broadcasting to shape (ncol,
ncol). To prevent this, we can remove the direct access to values so
that xarray will always do smart broadcasting, but to ensure that
computed arrays end up with our desired shape of (ntime, ncol) as
opposed to (ncol, ntime) we also explicitly broadcast del_phis to the
shape of PS.