### PR TITLE
Fix relative import of hiccup_state_adjustment

### DIFF
--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -12,7 +12,7 @@ import datetime
 # import cftime
 import os, sys, re, shutil
 from time import perf_counter
-import hiccup_state_adjustment as hsa
+from . import hiccup_state_adjustment as hsa
 
 # default output paths
 default_output_dir  = './data/'


### PR DESCRIPTION
Fix relative import of hiccup_state_adjustment from hiccup_data_class.
This fixes the bug where hiccup_data_class assumed that
hiccup_state_adjustment lives in the users current path, so that imports
from outside the source directory would fail even if HICCUP was
installed via setup.py or pip. The import line now specifies that
hiccup_state_adjustment lives in the same path as hiccup_data_class.
This also allows importing either of these routines from within the
source directory for development purposes.