### PR TITLE
add nudging support for SCREAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@ exodus_*
 scrip_*
 map_*
 *.png
+custom_scripts/*
 files_grid/*
 files_mapping/*
 files_tmp/*
 test_data_tmp/*
+data_scratch
+data/*
 data_scratch/*
 slurm*out
 build/

--- a/SCREAM_utils/check_converted_initial_condition.py
+++ b/SCREAM_utils/check_converted_initial_condition.py
@@ -1,0 +1,39 @@
+import numpy as np, xarray as xr
+
+# var_name,file_path = 'o3','/p/lustre1/hannah6/hiccup_scratch/gas_constituents_ne30np4L128_20220711.permuted.nc'
+# var_name,file_path = 'o3_volume_mix_ratio','/p/lustre1/hannah6/hiccup_scratch/HICCUP.atm_era5.2006-08-09.ne30np4.L128.converted.nc'
+# var_name,file_path = 'O3','/p/lustre1/hannah6/hiccup_scratch/HICCUP.atm_era5.2006-08-09.ne30np4.L128.nc'
+
+# var_name,file_path = 'o3','/p/lustre1/hannah6/2024-saomai-data/gas_constituents_ne30np4L128_20220711.permuted.nc'
+# var_name,file_path = 'o3','/p/lustre1/hannah6/2024-saomai-data/gas_constituents_ne0np4-saomai-128x8-pg2-L128_20240110.nc'
+# var_name,file_path = 'o3','/p/lustre1/hannah6/2024-saomai-data/gas_constituents_ne0np4-saomai-128x8-pg2-L128_20240110.permuted.nc'
+var_name,file_path = 'o3_volume_mix_ratio','/p/lustre1/hannah6/2024-saomai-data/HICCUP.atm_era5.2006-08-09.Saomai_2006_ne128x8_lon130E_lat25N.L128.converted.nc'
+
+print()
+print(f'file: {file_path}')
+print(f'var:  {var_name}')
+print()
+
+ds = xr.open_dataset(file_path)
+
+data = ds[var_name]
+
+any_isnan = np.any(np.isnan(data.values))
+any_isinf = np.any(np.isinf(data.values))
+any_isneg = np.any( data.values<0 )
+
+print()
+print(f'  any isnan: {any_isnan}')
+print(f'  any isinf: {any_isnan}')
+print(f'  any isneg: {any_isneg}')
+print()
+
+# if True:
+if any_isneg:
+  for e in reversed(range(10)):
+    p = -1*e
+    chk_val = -1* np.power(10.,p)
+    chk = np.any( data.values < chk_val )
+    print(f'  any less than -10^{p:2d} ( {chk_val:+1.10f} ) : {chk}')
+
+print()

--- a/SCREAM_utils/convert_eami_to_screami.py
+++ b/SCREAM_utils/convert_eami_to_screami.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import xarray, numpy, dask, sys
+from subprocess import call
+
+'''
+usage: convert_eami_to_screami.py [-h] inputfile topofile gasfile outputfile
+
+topofile=/global/cfs/cdirs/e3sm/inputdata/atm/cam/topo/USGS-gtopo30_ne256np4_16xdel2_consistentSGH_20220429.nc
+gasfile=/global/cfs/cdirs/e3sm/whannah/init_data/gas_constituents_ne256np4L128_20230222.nc
+inputfile=/global/cfs/cdirs/m2637/jsgoodni/HICCUP.atm_era5.2006-08-09.Saomai_2006_ne128x8_lon130E_lat25N.L128.nc
+outputfile=/global/cfs/cdirs/m2637/whannah/HICCUP.atm_era5.2006-08-09.Saomai_2006_ne128x8_lon130E_lat25N.L128.converted.nc
+python3 convert_eami_to_screami.py $inputfile $topofile $gasfile $outputfile
+'''
+
+def print_message(message):
+    print(message); sys.stdout.flush()
+
+
+def main(inputfile, gasfile, outputfile):
+
+    # Stuff we need to get from cami file
+    screami_from_cami_coordvars = {  # These we want to be doubles
+        'time': 'time',
+        'hyam': 'hyam',
+        'hybm': 'hybm',
+        'hyai': 'hyai',
+        'hybi': 'hybi',
+        'pref_mid': 'lev', #hybm
+        'lat' : 'lat',
+        'lon' : 'lon',
+        'P0'  : 'P0',
+    }
+    screami_from_cami_datavars = {  # These can be floats
+        'qv'  : 'Q',
+        'ps'  : 'PS',
+        'T_mid': 'T',
+        'qc': 'CLDLIQ',
+        'qi': 'CLDICE',
+        'qr': 'RAINQM',
+        'nc': 'NUMLIQ',
+        'ni': 'NUMICE',
+        'nr': 'NUMRAI',
+    }
+    screami_from_cami = {**screami_from_cami_coordvars, **screami_from_cami_datavars}
+
+    # Other things we need:
+    #   gas concentrations for trace gas constituents (only o3 now)
+    #   surface geopotential
+    gas_names = ('o3',)
+
+    with xarray.open_dataset(inputfile, decode_cf=False) as ds_in:
+
+        ds_out = xarray.Dataset()
+
+        ntime = ds_in.sizes['time']
+        ncol = ds_in.sizes['ncol']
+        nlev = ds_in.sizes['lev']
+
+        # Fields we can copy directly
+        print_message('Copy fields from cami')
+        for scream_name, eam_name in screami_from_cami.items():
+            print_message(f'  {eam_name} -> {scream_name}')
+            if eam_name in ds_in.variables.keys():
+                ds_out[scream_name] = ds_in[eam_name]
+            else:
+                print_message(f'WARNING: {eam_name} not found in inputfile; hope you did not need that one...')
+
+        # Make sure ps field contains a time dimension
+        if 'time' not in ds_out['ps'].dims:
+            ds_out['ps'] = ds_out['ps'].expand_dims('time', axis=0)
+
+        # Handle U,V to horiz_winds(time,ncol,dim2,lev)
+        print_message('Map U,V to horiz_winds')
+        ds_out['horiz_winds'] = xarray.concat([ds_in['U'], ds_in['V']], 'dim2')
+
+        # Grab trace gas concentrations from file
+        print_message('Get trace gases')
+        with xarray.open_dataset(gasfile, decode_cf=False).isel(time=0).drop('time') as ds_gas:
+            for v in gas_names:
+                print_message(f'  get {v} from gas file...')
+                ds_out[v + '_volume_mix_ratio'] = xarray.DataArray(
+                    numpy.zeros([ncol, nlev], dtype=float), 
+                    dims=('ncol', 'lev'),
+                    attrs=ds_gas[v].attrs
+                )
+                ds_out[v + '_volume_mix_ratio'].values = ds_gas[v].transpose('ncol', 'lev').values
+                ds_out[v + '_volume_mix_ratio'], *__ = xarray.broadcast(ds_out[v + '_volume_mix_ratio'], ds_out['ps'])
+                ds_out[v + '_volume_mix_ratio'].attrs['units'] = 'mol/mol'
+                ds_out[v + '_volume_mix_ratio'].attrs['long_name'] = v + ' volume mixing ratio'
+
+        # Convert datavars to single precision float
+        for v in ds_out.data_vars.keys():
+            if v not in screami_from_cami_coordvars.keys():
+                print_message(f'convert {v} to float...')
+                ds_out[v] = ds_out[v].astype(numpy.float32)
+
+        # Permute dimensions
+        print_message('Permute dimensions')
+        try:
+            if 'nbnd' in ds_out.dims:
+                ds_out = ds_out.transpose('time','ncol','dim2','lev','ilev','nbnd')
+            else:
+                ds_out = ds_out.transpose('time','ncol','dim2','lev','ilev')
+        except:
+            print_message('  permute dimensions failed, but continuing anyways.')
+
+        # Apply clipping
+        for v in ('qv', 'qc', 'qi', 'qr', 'nc', 'ni', 'nr'):
+            if v in ds_out.variables.keys():
+                ds_out[v].data = numpy.where(ds_out[v] < 0, 0, ds_out[v])
+
+        # Check values
+        for v in ds_out.variables:
+            numnan = ds_out[v].isnull().sum().values
+            print_message(f'{v} numnan = {numnan}')
+
+        print_message('Write to netcdf')
+        ds_out.to_netcdf(outputfile) #format="NETCDF3_64BIT")
+
+        # Convert to cdf5
+        print_message('Convert to cdf5')
+        call(f'ncks -5 {outputfile} {outputfile}.cdf5'.split(' '))
+        call(f'mv {outputfile}.cdf5 {outputfile}'.split(' '))
+
+        print_message('Done.')
+
+        print_message()
+        print_message(f'  outputfile: {outputfile}')
+        print_message()
+
+if __name__ == '__main__':
+    import plac; plac.call(main)

--- a/SCREAM_utils/convert_eami_to_screami.py
+++ b/SCREAM_utils/convert_eami_to_screami.py
@@ -124,9 +124,9 @@ def main(inputfile, gasfile, outputfile):
 
         print_message('Done.')
 
-        print_message()
+        print_message('')
         print_message(f'  outputfile: {outputfile}')
-        print_message()
+        print_message('')
 
 if __name__ == '__main__':
     import plac; plac.call(main)

--- a/SCREAM_utils/convert_eami_to_screami_old.py
+++ b/SCREAM_utils/convert_eami_to_screami_old.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+import xarray, numpy, dask
+from subprocess import call
+
+# usage:
+# convert_cami_to_screami.py [-h] inputfile topofile gasfile outputfile
+
+'''
+topofile=/global/cfs/cdirs/e3sm/inputdata/atm/cam/topo/USGS-gtopo30_ne256np4_16xdel2_consistentSGH_20220429.nc
+gasfile=/global/cfs/cdirs/e3sm/whannah/init_data/gas_constituents_ne256np4L128_20230222.nc
+inputfile=/global/cfs/projectdirs/m3312/whannah/HICCUP/eami.HICCUP-ERA5.2010-01-01.ne256np4.L128v1.c20230217.nc
+outputfile=/global/cfs/projectdirs/m3312/whannah/HICCUP/eami.HICCUP-ERA5.2010-01-01.ne256np4.L128v1.c20230222.nc
+python3 convert_cami_to_screami.py $inputfile $topofile $gasfile $outputfile
+'''
+
+
+'''
+topofile=/global/cfs/cdirs/e3sm/inputdata/atm/cam/topo/USGS-gtopo30_ne256np4_16xdel2_consistentSGH_20220429.nc
+gasfile=/global/cfs/cdirs/e3sm/whannah/init_data/gas_constituents_ne256np4L128_20230222.nc
+inputfile=/global/cfs/projectdirs/m3312/whannah/HICCUP/eami.HICCUP-ERA5.2010-01-01.ne256np4.L128v2.1.c20230217.nc
+outputfile=/global/cfs/projectdirs/m3312/whannah/HICCUP/eami.HICCUP-ERA5.2010-01-01.ne256np4.L128v2.1.c20230222.nc
+time python3 convert_cami_to_screami.py $inputfile $topofile $gasfile $outputfile
+'''
+
+
+'''
+topofile=/global/cfs/cdirs/e3sm/inputdata/atm/cam/topo/USGS-gtopo30_ne256np4_16xdel2_consistentSGH_20220429.nc
+gasfile=/global/cfs/cdirs/e3sm/whannah/init_data/gas_constituents_ne256np4L128_20230222.nc
+inputfile=/global/cfs/projectdirs/m3312/whannah/HICCUP/eami.HICCUP-ERA5.2010-01-01.ne256np4.L128v2.2.c20230217.nc
+outputfile=/global/cfs/projectdirs/m3312/whannah/HICCUP/eami.HICCUP-ERA5.2010-01-01.ne256np4.L128v2.2.c20230222.nc
+python3 convert_cami_to_screami.py $inputfile $topofile $gasfile $outputfile
+'''
+
+
+
+def main(inputfile, topofile, gasfile, outputfile):
+# def main(inputfile,outputfile):
+
+    # Stuff we need to get from cami file
+    screami_from_cami_coordvars = {  # These we want to be doubles
+        'time': 'time',
+        'hyam': 'hyam',
+        'hybm': 'hybm',
+        'hyai': 'hyai',
+        'hybi': 'hybi',
+        'pref_mid': 'lev', #hybm
+        'lat' : 'lat',
+        'lon' : 'lon',
+        'P0'  : 'P0',
+    }
+    screami_from_cami_datavars = {  # These can be floats
+        'qv'  : 'Q',
+        'ps'  : 'PS',
+        'T_mid': 'T',
+        'qc': 'CLDLIQ',
+        'qi': 'CLDICE',
+        'qr': 'RAINQM',
+        'nc': 'NUMLIQ',
+        'ni': 'NUMICE',
+        'nr': 'NUMRAI',
+    }
+    screami_from_cami = {**screami_from_cami_coordvars, **screami_from_cami_datavars}
+
+    # Other things we need:
+    #   gas concentrations for trace gas constituents (only o3 now)
+    #   surface geopotential
+    gas_names = ('o3',)
+
+    with xarray.open_dataset(inputfile, decode_cf=False) as ds_in:
+
+        ds_out = xarray.Dataset()
+
+        ntime = ds_in.sizes['time']
+        ncol = ds_in.sizes['ncol']
+        nlev = ds_in.sizes['lev']
+
+        # Fields we can copy directly
+        print('Copy fields from cami')
+        for scream_name, eam_name in screami_from_cami.items():
+            print(f'  {eam_name} -> {scream_name}')
+            if eam_name in ds_in.variables.keys():
+                ds_out[scream_name] = ds_in[eam_name]
+            else:
+                print(f'WARNING: {eam_name} not found in inputfile; hope you did not need that one...')
+
+        # Make sure ps field contains a time dimension
+        if 'time' not in ds_out['ps'].dims:
+            ds_out['ps'] = ds_out['ps'].expand_dims('time', axis=0)
+
+        # Handle U,V to horiz_winds(time,ncol,dim2,lev)
+        print('Map U,V to horiz_winds')
+        ds_out['horiz_winds'] = xarray.concat([ds_in['U'], ds_in['V']], 'dim2')
+
+        # Grab phis from topo file
+        print('Grab phis from topo file')
+        with xarray.open_dataset(topofile, decode_cf=False) as ds_topo:
+            if 'PHIS_d' in ds_topo.variables.keys():
+                print('  use PHIS_d')
+                ds_out['phis'] = ds_topo['PHIS_d'].rename({'ncol_d': 'ncol'})
+            else:
+                print('  use PHIS')
+                ds_out['phis'] = ds_topo['PHIS']
+        # Broadcast phis to include time dim
+        ds_out['phis'], *__ = xarray.broadcast(ds_out['phis'], ds_out['ps'])
+
+        # Grab trace gas concentrations from file
+        print('Get trace gases')
+        with xarray.open_dataset(gasfile, decode_cf=False).isel(time=0).drop('time') as ds_gas:
+            for v in gas_names:
+                print(f'  get {v} from gas file...')
+                ds_out[v + '_volume_mix_ratio'] = xarray.DataArray(
+                    numpy.zeros([ncol, nlev], dtype=float), 
+                    dims=('ncol', 'lev'),
+                    attrs=ds_gas[v].attrs
+                )
+                ds_out[v + '_volume_mix_ratio'].values = ds_gas[v].transpose('ncol', 'lev').values
+                ds_out[v + '_volume_mix_ratio'], *__ = xarray.broadcast(ds_out[v + '_volume_mix_ratio'], ds_out['ps'])
+                ds_out[v + '_volume_mix_ratio'].attrs['units'] = 'mol/mol'
+                ds_out[v + '_volume_mix_ratio'].attrs['long_name'] = v + ' volume mixing ratio'
+
+        # Convert datavars to single precision float
+        for v in ds_out.data_vars.keys():
+            if v not in screami_from_cami_coordvars.keys():
+                print(f'convert {v} to float...')
+                ds_out[v] = ds_out[v].astype(numpy.float32)
+
+        # Permute dimensions
+        print('Permute dimensions')
+        try:
+            if 'nbnd' in ds_out.dims:
+                ds_out = ds_out.transpose('time','ncol','dim2','lev','ilev','nbnd')
+            else:
+                ds_out = ds_out.transpose('time','ncol','dim2','lev','ilev')
+        except:
+            print('  permute dimensions failed, but continuing anyways.')
+
+        # Apply clipping
+        for v in ('qv', 'qc', 'qi', 'qr', 'nc', 'ni', 'nr'):
+            if v in ds_out.variables.keys():
+                ds_out[v].data = numpy.where(ds_out[v] < 0, 0, ds_out[v])
+
+        # Check values
+        for v in ds_out.variables:
+            numnan = ds_out[v].isnull().sum().values
+            print(f'{v} numnan = {numnan}')
+
+        print('Write to netcdf')
+        ds_out.to_netcdf(outputfile) #format="NETCDF3_64BIT")
+
+        # Convert to cdf5
+        print('Convert to cdf5')
+        call(f'ncks -5 {outputfile} {outputfile}.cdf5'.split(' '))
+        call(f'mv {outputfile}.cdf5 {outputfile}'.split(' '))
+
+        print('Done.')
+
+        print()
+        print(f'  outputfile: {outputfile}')
+        print()
+
+if __name__ == '__main__':
+    import plac; plac.call(main)

--- a/SCREAM_utils/generate_gasfile.sh
+++ b/SCREAM_utils/generate_gasfile.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#SBATCH -N 1
+###SBATCH -C cpu
+#SBATCH -C knl
+#SBATCH -t 01:00:00
+#SBATCH -q regular
+#SBATCH -A e3sm
+#SBATCH -o remap_gases-%j.out
+
+# use this command to submit:
+# sbatch generate_gasfile.sh
+
+module load python
+
+# conda activate nco-cmem
+conda activate hiccup_env
+
+dst_res=256
+
+# output_root=/global/cfs/cdirs/e3sm/bhillma/scream/data/init
+output_root=/global/cfs/cdirs/e3sm/whannah/init_data
+
+# input_gas_file=${output_root}/gas_constituents_ne30np4L128_20220711.permuted.nc
+input_gas_file=/global/cfs/cdirs/e3sm/bhillma/scream/data/init/gas_constituents_ne30np4L128_20220711.permuted.nc
+output_gas_file=${output_root}/gas_constituents_ne${dst_res}np4L128_`date +%Y%m%d`.nc
+
+# map_file=$SCRATCH/grids/ne1024/map_ne30_to_1024_highorder_20220912.nc
+map_file=/global/cfs/projectdirs/m3312/whannah/HICCUP/files_map/map_ne30np4_to_ne256np4.20221212.nc
+#map_file=${output_root}/ne${dst_res}/map_ne${src_res}_to_${dst_res}_highorder.nc
+
+# Convert data format
+srun ncremap -m ${map_file} ${input_gas_file} ${output_gas_file}.permuted
+srun ncpdq -a time,ncol,lev ${output_gas_file}.permuted ${output_gas_file}

--- a/SCREAM_utils/generate_gasfile_RRM.sh
+++ b/SCREAM_utils/generate_gasfile_RRM.sh
@@ -31,11 +31,10 @@ output_gas_file=${output_root}/gas_constituents_ne0np4-saomai-128x8-pg2-L128_`da
 map_file=/global/cfs/cdirs/m2637/whannah/map_ne30np4_to_ne0np4-saomai-128x8.nc
 
 # Convert data format
-echo
-echo srun ncremap -m ${map_file} ${input_gas_file} ${output_gas_file}.permuted
-echo
-srun ncremap -m ${map_file} ${input_gas_file} ${output_gas_file}.permuted
-echo
-echo srun ncpdq --ovr -a time,ncol,lev ${output_gas_file}.permuted ${output_gas_file}
-echo
-srun ncpdq --ovr -a time,ncol,lev ${output_gas_file}.permuted ${output_gas_file}
+CMD=ncremap -m ${map_file} ${input_gas_file} ${output_gas_file}.permuted
+echo; echo srun $CMD
+echo; srun $CMD
+
+CMD=ncpdq --ovr -a time,ncol,lev ${output_gas_file}.permuted ${output_gas_file}
+echo; echo srun $CMD
+echo; srun $CMD

--- a/SCREAM_utils/generate_gasfile_RRM.sh
+++ b/SCREAM_utils/generate_gasfile_RRM.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --constraint=cpu
+#SBATCH --account=m2637
+#SBATCH --qos=regular
+#SBATCH --time=2:00:00
+#SBATCH -o remap_gases-%j.out
+#SBATCH --mail-user=hannah6@llnl.gov
+#SBATCH --mail-type=END,FAIL
+
+# use this command to submit
+# sbatch generate_gasfile_RRM.sh
+
+module load python/3.9-anaconda-2021.11
+
+source activate hiccup_env
+
+# output_root=/global/cfs/cdirs/e3sm/bhillma/scream/data/init
+output_root=/global/cfs/cdirs/e3sm/whannah/init_data
+
+# input_gas_file=${output_root}/gas_constituents_ne30np4L128_20220711.permuted.nc
+input_gas_file=/global/cfs/cdirs/e3sm/bhillma/scream/data/init/gas_constituents_ne30np4L128_20220711.permuted.nc
+output_gas_file=${output_root}/gas_constituents_ne0np4-saomai-128x8-pg2-L128_`date +%Y%m%d`.nc
+
+# commands for map file generation
+# SRC_GRID=/global/homes/w/whannah/E3SM/data_grid/ne30.g
+# DST_GRID=/global/cfs/cdirs/m2637/jsgoodni/Saomai_2006_ne128x8_lon130E_lat25N.g
+# MAP_FILE=/global/cfs/cdirs/m2637/whannah/map_ne30np4_to_ne0np4-saomai-128x8.nc
+# ncremap -a tempest --src_grd=${SRC_GRID} --dst_grd=${DST_GRID} --map_file=${MAP_FILE} --wgt_opt='--in_type cgll --in_np 4 --out_type cgll --out_np 4 --out_double'
+
+map_file=/global/cfs/cdirs/m2637/whannah/map_ne30np4_to_ne0np4-saomai-128x8.nc
+
+# Convert data format
+echo
+echo srun ncremap -m ${map_file} ${input_gas_file} ${output_gas_file}.permuted
+echo
+srun ncremap -m ${map_file} ${input_gas_file} ${output_gas_file}.permuted
+echo
+echo srun ncpdq --ovr -a time,ncol,lev ${output_gas_file}.permuted ${output_gas_file}
+echo
+srun ncpdq --ovr -a time,ncol,lev ${output_gas_file}.permuted ${output_gas_file}

--- a/SCREAM_utils/permute_dimensions.py
+++ b/SCREAM_utils/permute_dimensions.py
@@ -1,0 +1,43 @@
+
+import os, datetime, xarray as xr, pandas as pd
+
+bdate_str,edate_str = '2020-01-21 00','2020-01-26 21' # 2024 SCREAM - autocalibration
+
+# Create list of date and time 
+beg_date = datetime.datetime.strptime(bdate_str, '%Y-%m-%d %H')
+end_date = datetime.datetime.strptime(edate_str, '%Y-%m-%d %H')
+datetime_list = pd.date_range(beg_date, end_date, freq='1D')
+
+data_root = '/lustre/orion/cli115/proj-shared/hannah6/scream_scratch/nudge_data'
+dst_horz_grid = 'ne128pg2'
+dst_vert_grid = 'L128'
+
+ref_date = '2000-01-01'
+
+# ------------------------------------------------------------------------------
+for t in datetime_list:
+
+    nudge_datetime = t.strftime("%Y-%m-%d")
+
+    data_file_name = f'{data_root}/HICCUP.nudging_uv_era5.{nudge_datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
+
+    print();print(' '*4+f'{data_file_name}')
+
+    print();print(' '*4+'Transposing data dimensions...')
+
+    cmd = f'ncpdq -5 -a time,ncol,lev {data_file_name}'
+    hdc.run_cmd(cmd,verbose=True,shell=True,prefix=hdc.verbose_indent)
+
+    # ds = xr.open_dataset(data_file_name)
+    # transpose_flag = False
+    # for v in ds.variables:
+    #   if ds[v].dims==('time','lev','ncol'):
+    #     print(' '*6+f'var: {v}')
+    #     transpose_flag = True
+    #     ds[v] = ds[v].transpose('time','ncol','lev')
+    # if transpose_flag:
+    #   time_encoding_dict = {'time':{'units': f'hours since {ref_date} 00:00:00'}}
+    #   ds.to_netcdf(data_file_name,format='NETCDF3_64BIT_DATA',mode='w',encoding=time_encoding_dict)
+    #   # ds.to_netcdf(data_file_name,format='NETCDF4',mode='w',encoding=time_encoding_dict)
+    # ds.close()
+# ------------------------------------------------------------------------------

--- a/get_hindcast_data.ERA5.py
+++ b/get_hindcast_data.ERA5.py
@@ -35,9 +35,9 @@ lev = [  '1',  '2',  '3',  '5',  '7', '10', '20', '30', '50', '70'
 # lev = [ '50','100','150','200','300','400','500','600'
 #       ,'700','750','800','850','900','950','1000']
 
-output_path = os.getenv('PWD')+'/data_scratch/'
+output_path = os.getenv('PWD')+'/data_scratch'
 
-# output_file_plv = output_path+'HICCUP_TEST.ERA5.atm.nc'
+# output_file_plv = output_path+'/HICCUP_TEST.ERA5.atm.nc'
 # output_file_sfc = output_file_plv.replace('atm.nc','sfc.nc')
 # output_file_lnd = output_file_plv.replace('atm.nc','lnd.nc')
 
@@ -49,7 +49,7 @@ for i in range(len(yr_list)):
   time = time_list[i]
 
   # output_file_plv = output_path+f'ERA5.atm.{yr_list[0]}-{mn_list[0]}-{dy_list[0]}.nc'
-  output_file_plv = output_path+f'ERA5.atm.{yr}-{mn}-{dy}.nc'
+  output_file_plv = output_path+f'/ERA5.atm.{yr}-{mn}-{dy}.nc'
   output_file_mlv = output_file_plv.replace('.atm.','.mlev.')
   output_file_sfc = output_file_plv.replace('.atm.','.sfc.')
   output_file_lnd = output_file_plv.replace('.atm.','.lnd.')

--- a/get_nudging_data.ERA5.py
+++ b/get_nudging_data.ERA5.py
@@ -1,0 +1,58 @@
+import os, cdsapi, datetime, pandas as pd
+from datetime import date, timedelta
+server = cdsapi.Client()
+
+get_atm = True
+get_sfc = True
+
+# bdate_str,edate_str = '2006-08-09 00','2006-08-13 21' # 2024 Nimbus - Typhoon Saomai
+bdate_str,edate_str = '2020-01-20 00','2020-01-25 21' # 2024 SCREAM - autocalibration
+
+# Create list of date and time 
+beg_date = datetime.datetime.strptime(bdate_str, '%Y-%m-%d %H')
+end_date = datetime.datetime.strptime(edate_str, '%Y-%m-%d %H')
+datetime_list = pd.date_range(beg_date, end_date, freq='3H')
+
+# All available pressure levels
+lev = [  '1',  '2',  '3',  '5',  '7', '10', '20', '30', '50', '70','100','125','150','175','200'
+      ,'225','250','300','350','400','450','500','550','600','650','700','750','775','800','825'
+      ,'850','875','900','925','950','975','1000']
+
+# output_path = '/global/cfs/cdirs/m2637/whannah/nudge_data'
+output_path = '/global/cfs/cdirs/m3312/whannah/nudge_data'
+
+# ------------------------------------------------------------------------------
+for t in datetime_list:
+   yr = t.strftime("%Y")
+   mn = t.strftime("%m")
+   dy = t.strftime("%d")
+   hr = t.strftime("%H")
+   # ---------------------------------------------------------------------------
+   output_file_plv = f'{output_path}/ERA5.atm.{yr}-{mn}-{dy}-{hr}:00.nc'
+   output_file_sfc = f'{output_path}/ERA5.sfc.{yr}-{mn}-{dy}-{hr}:00.nc'
+   # ---------------------------------------------------------------------------
+   # atmosphere pressure level data
+   if get_atm:
+      server.retrieve('reanalysis-era5-pressure-levels',{
+         'product_type'  : 'reanalysis',
+         'pressure_level': lev,
+         'time'          : f'{hr}:00',
+         'day'           : dy,
+         'month'         : mn,
+         'year'          : yr,
+         'format'        : 'netcdf',
+         'variable'      : ['u_component_of_wind', 'v_component_of_wind']
+      }, output_file_plv)
+   # ---------------------------------------------------------------------------
+   # surface data
+   if get_sfc:
+      server.retrieve('reanalysis-era5-single-levels',{
+         'product_type'  : 'reanalysis',
+         'time'          : f'{hr}:00',
+         'day'           : dy,
+         'month'         : mn,
+         'year'          : yr,
+         'format'        : 'netcdf',
+         'variable'      : ['surface_pressure']
+      }, output_file_sfc)
+   # ----------------------------------------------------------------------------

--- a/get_nudging_data.ERA5.py
+++ b/get_nudging_data.ERA5.py
@@ -5,8 +5,7 @@ server = cdsapi.Client()
 get_atm = True
 get_sfc = True
 
-# bdate_str,edate_str = '2006-08-09 00','2006-08-13 21' # 2024 Nimbus - Typhoon Saomai
-bdate_str,edate_str = '2020-01-20 00','2020-01-25 21' # 2024 SCREAM - autocalibration
+bdate_str,edate_str = '2020-01-20 00','2020-01-26 21' # 2024 SCREAM autocalibration (DYAMOND2)
 
 # Create list of date and time 
 beg_date = datetime.datetime.strptime(bdate_str, '%Y-%m-%d %H')
@@ -18,8 +17,9 @@ lev = [  '1',  '2',  '3',  '5',  '7', '10', '20', '30', '50', '70','100','125','
       ,'225','250','300','350','400','450','500','550','600','650','700','750','775','800','825'
       ,'850','875','900','925','950','975','1000']
 
-# output_path = '/global/cfs/cdirs/m2637/whannah/nudge_data'
-output_path = '/global/cfs/cdirs/m3312/whannah/nudge_data'
+output_path = os.getenv('HOME')+'/HICCUP/data_scratch/nudge_data'
+
+os.makedirs(output_path, exist_ok=True)
 
 # ------------------------------------------------------------------------------
 for t in datetime_list:

--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -442,7 +442,7 @@ class hiccup_data(object):
 
         if src_type is not None and src_type not in ['FV','GLL']:
             raise ValueError(f'The value of src_type={src_type} is not supported')
-        if dst_type is not None and dst_type not in ['GLL']:
+        if dst_type is not None and dst_type not in ['FV','GLL']:
             raise ValueError(f'The value of src_type={src_type} is not supported')
         
         ne = self.get_dst_grid_ne()
@@ -451,6 +451,7 @@ class hiccup_data(object):
         self.map_opts = ''
         if src_type=='FV' : self.map_opts += ' --in_type fv --in_np 1 '
         if src_type=='GLL': self.map_opts += ' --in_type cgll --in_np 4 '
+        if dst_type=='FV' : self.map_opts += ' --out_type fv --out_np 1 '
         if dst_type=='GLL': self.map_opts += ' --out_type cgll --out_np 4 '
         self.map_opts += ' --out_double '
         
@@ -1710,6 +1711,13 @@ class ERA5(hiccup_data):
             self.sfc_var_name_dict.update({'PS':'sp'})         # sfc pressure
             # self.sfc_var_name_dict.update({'TS':'skt'})        # skin temperature
             self.sfc_var_name_dict.update({'PHIS':'z'})        # surface geopotential
+
+        if target_model=='EAMXX-nudging':
+            self.atm_var_name_dict.update({'lat':'latitude'})
+            self.atm_var_name_dict.update({'lon':'longitude'})
+            self.sfc_var_name_dict.update({'PS':'sp'})          # sfc pressure
+            self.atm_var_name_dict.update({'U':'u'})            # zonal wind
+            self.atm_var_name_dict.update({'V':'v'})            # meridional wind
 
         self.src_nlat = len( self.ds_atm[ self.atm_var_name_dict['lat'] ].values )
         self.src_nlon = len( self.ds_atm[ self.atm_var_name_dict['lon'] ].values )

--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -193,7 +193,8 @@ def create_hiccup_data(name,dst_horz_grid=None,dst_vert_grid=None,
                       ,grid_dir=grid_dir
                       ,map_dir=map_dir
                       ,tmp_dir=tmp_dir
-                      ,lev_type=lev_type)
+                      ,lev_type=lev_type
+                      ,check_input_files=check_input_files)
 
             # Check input files for for required variables
             if check_input_files: obj.check_file_vars()
@@ -221,7 +222,7 @@ class hiccup_data(object):
                  output_dir=default_output_dir,grid_dir=default_grid_dir,
                  map_dir=default_map_dir,tmp_dir=default_tmp_dir,
                  sstice_combined_file=None,sstice_name=None,topo_file=None,
-                 sst_file=None,ice_file=None,lev_type=''):
+                 sst_file=None,ice_file=None,lev_type='',check_input_files=True):
         self.lev_type = lev_type
         self.atm_file = atm_file
         self.sfc_file = sfc_file
@@ -270,11 +271,12 @@ class hiccup_data(object):
         if self.sstice_name=='ERA5': self.sst_name,self.ice_name = 'sst','siconc'
 
         # Check that input files exist
-        for file_name in [self.atm_file,self.sfc_file,self.sst_file
-                         ,self.ice_file,self.topo_file]:
-            if file_name is not None:
-                if not os.path.exists(file_name):
-                    raise ValueError(f'input file does not exist: {file_name}')
+        if check_input_files:
+            for file_name in [self.atm_file,self.sfc_file,self.sst_file
+                             ,self.ice_file,self.topo_file]:
+                if file_name is not None:
+                    if not os.path.exists(file_name):
+                        raise ValueError(f'input file does not exist: {file_name}')
 
         # Load input files into xarray datasets
         if self.atm_file is not None: self.ds_atm = xr.open_dataset(self.atm_file)
@@ -1680,7 +1682,7 @@ class ERA5(hiccup_data):
                  output_dir=default_output_dir,grid_dir=default_grid_dir,
                  map_dir=default_map_dir,tmp_dir=default_tmp_dir,
                  sstice_name=None,sst_file=None,ice_file=None,topo_file=None,
-                 sstice_combined_file=None,lev_type=''):
+                 sstice_combined_file=None,lev_type='',check_input_files=True):
         super().__init__(atm_file=atm_file
                         ,sfc_file=sfc_file
                         ,dst_horz_grid=dst_horz_grid
@@ -1694,7 +1696,8 @@ class ERA5(hiccup_data):
                         ,grid_dir=grid_dir
                         ,map_dir=map_dir
                         ,tmp_dir=tmp_dir
-                        ,lev_type=lev_type)
+                        ,lev_type=lev_type
+                        ,check_input_files=check_input_files)
         
         self.name = 'ERA5'
         self.lev_name = 'level'
@@ -1850,7 +1853,7 @@ class NOAA(hiccup_data):
                  output_dir=default_output_dir,grid_dir=default_grid_dir,
                  map_dir=default_map_dir,tmp_dir=default_tmp_dir,
                  sstice_name=None,sst_file=None,ice_file=None,topo_file=None,
-                 sstice_combined_file=None,lev_type=''):
+                 sstice_combined_file=None,lev_type='',check_input_files=True):
         super().__init__(atm_file=atm_file
                         ,sfc_file=sfc_file
                         ,dst_horz_grid=dst_horz_grid
@@ -1864,7 +1867,8 @@ class NOAA(hiccup_data):
                         ,grid_dir=grid_dir
                         ,map_dir=map_dir
                         ,tmp_dir=tmp_dir
-                        ,lev_type=lev_type)
+                        ,lev_type=lev_type
+                        ,check_input_files=check_input_files)
         
         self.name = 'NOAA'
         self.sstice_name=='NOAA'
@@ -1891,7 +1895,7 @@ class EAM(hiccup_data):
                  output_dir=default_output_dir,grid_dir=default_grid_dir,
                  map_dir=default_map_dir,tmp_dir=default_tmp_dir,
                  sstice_name=None,sst_file=None,ice_file=None,topo_file=None,
-                 sstice_combined_file=None,lev_type=''):
+                 sstice_combined_file=None,lev_type='',check_input_files=True):
         super().__init__(atm_file=atm_file
                         ,sfc_file=sfc_file
                         ,dst_horz_grid=dst_horz_grid
@@ -1905,7 +1909,8 @@ class EAM(hiccup_data):
                         ,grid_dir=grid_dir
                         ,map_dir=map_dir
                         ,tmp_dir=tmp_dir
-                        ,lev_type=lev_type)
+                        ,lev_type=lev_type
+                        ,check_input_files=check_input_files)
         
         self.name = 'EAM'
         self.lev_name = 'lev'

--- a/template_scripts/SCREAM_process_nudging_data.py
+++ b/template_scripts/SCREAM_process_nudging_data.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# ==================================================================================================
+# HICCUP - Hindcast Initial Condition Creation Utility/Processor
+# ==================================================================================================
+import os, datetime, pandas as pd
+import xarray as xr
+from hiccup import hiccup_data_class as hdc
+from hiccup import hiccup_state_adjustment as hsa
+# ------------------------------------------------------------------------------
+# Logical flags for controlling what this script will do (comment out to disable)
+verbose = True            # Global verbosity flag
+# unpack_nc_files = True    # unpack data files (convert short to float)
+# create_map_file = True    # grid and map file creation
+# remap_data_horz = True    # horz remap, variable renaming
+# remap_data_vert = True    # vertical remap
+# combine_files   = True    # combine temporary data files and delete
+# add_pressure    = True
+combine_daily   = True
+# ------------------------------------------------------------------------------
+
+# Create list of date and time 
+beg_date = datetime.datetime.strptime('2006-08-09 00', '%Y-%m-%d %H')
+end_date = datetime.datetime.strptime('2006-08-13 21', '%Y-%m-%d %H')
+datetime_list = pd.date_range(beg_date, end_date, freq='3H')
+
+# local path for grid, map, and data files
+hiccup_root = os.getenv('HOME')+'/HICCUP'
+src_data_root = '/global/cfs/cdirs/m2637/whannah/nudge_data'
+dst_data_root = '/global/cfs/cdirs/m2637/whannah/nudge_data'
+
+# Specify output atmosphere horizontal grid
+dst_horz_grid = 'ne0np4-saomai-128x8'
+
+# Specify output atmosphere vertical grid
+dst_vert_grid,vert_file_name = 'L128',f'{hiccup_root}/files_vert/vert_coord_E3SM_L128.nc'
+
+dst_grid_file = '/global/cfs/cdirs/m2637/jsgoodni/Saomai_2006_ne128x8_lon130E_lat25Npg2.scrip.nc'
+# map_file = '/global/cfs/cdirs/m2637/whannah/'
+
+hdc.target_model = 'EAMXX-nudging'
+hdc.verbose_indent = '  '
+
+# ------------------------------------------------------------------------------
+output_file_list = []
+for t in datetime_list:
+
+    nudge_datetime = t.strftime("%Y-%m-%d-%H")
+
+    src_atm_file = f'{src_data_root}/ERA5.atm.{nudge_datetime}:00.nc'
+    src_sfc_file = f'{src_data_root}/ERA5.sfc.{nudge_datetime}:00.nc'
+
+    output_atm_file_name = f'{dst_data_root}/HICCUP.nudging_uv_era5.{nudge_datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
+    output_file_list.append(output_atm_file_name)
+
+    # Create data class instance
+    hiccup_data = hdc.create_hiccup_data(name='ERA5'
+                                        ,dst_horz_grid=dst_horz_grid
+                                        ,dst_vert_grid=dst_vert_grid
+                                        ,atm_file=src_atm_file
+                                        ,sfc_file=src_sfc_file
+                                        ,topo_file=None
+                                        ,output_dir=dst_data_root
+                                        ,grid_dir=dst_data_root
+                                        ,map_dir=dst_data_root
+                                        ,tmp_dir=dst_data_root
+                                        ,verbose=verbose
+                                        ,check_input_files=False) # only need U/V
+    # Print some informative stuff
+    print('\n  Input Files')
+    print(f'    input atm files: {hiccup_data.atm_file}')
+    print(f'    input sfc files: {hiccup_data.sfc_file}')
+    print('\n  Output files')
+    print(f'    output atm file: {output_atm_file_name}')
+    # Get dict of temporary files for each variable
+    file_dict = hiccup_data.get_multifile_dict()
+    # # Specify mapping file
+    # hiccup_data.map_file = map_file
+    # --------------------------------------------------------------------------
+    # Make sure files are "unpacked" (may take awhile, so only do it if you need to)
+    if 'unpack_nc_files' not in locals(): unpack_nc_files = False
+    if unpack_nc_files:
+        hiccup_data.unpack_data_files()
+    # ------------------------------------------------------------------------------
+    # Create grid and mapping files
+    if 'create_map_file' not in locals(): create_map_file = False
+    if create_map_file :
+        # Create destination grid description file
+        hiccup_data.create_src_grid_file()
+        # specify destination grid file
+        hiccup_data.dst_grid_file = dst_grid_file
+        # Create mapping file
+        hiccup_data.create_map_file(src_type='FV',dst_type='FV')
+    # --------------------------------------------------------------------------
+    # perform multi-file horizontal remap
+    if 'remap_data_horz' not in locals(): remap_data_horz = False
+    if remap_data_horz :
+        # Horizontally regrid the data
+        hiccup_data.remap_horizontal_multifile(file_dict)
+        # Rename variables to match what the model expects
+        hiccup_data.rename_vars_multifile(file_dict=file_dict)
+        # Add time/date information
+        hiccup_data.add_time_date_variables_multifile(file_dict=file_dict)
+    # --------------------------------------------------------------------------
+    # Vertically remap the data
+    if 'remap_data_vert' not in locals(): remap_data_vert = False
+    if remap_data_vert :
+        hiccup_data.remap_vertical_multifile(file_dict=file_dict
+                                            ,vert_file_name=vert_file_name)
+    # --------------------------------------------------------------------------
+    # Combine files
+    if 'combine_files' not in locals(): combine_files = False
+    if combine_files :
+        # Combine and delete temporary files
+        hiccup_data.combine_files(file_dict=file_dict
+                                 ,delete_files=True
+                                 ,output_file_name=output_atm_file_name)
+        # Clean up the global attributes of the file
+        hiccup_data.clean_global_attributes(file_name=output_atm_file_name)
+    # --------------------------------------------------------------------------
+    # Use NCO to add p_mid field and case_t0 attribute
+    if 'add_pressure' not in locals(): add_pressure = False
+    if add_pressure:
+
+        print(hdc.verbose_indent+'\nAdding pressure field to nudging data...')
+
+        cmd = f'ncap2 -O -s \'p_mid[time,lev,ncol]=100000.0*hyam+PS*hybm\' {output_atm_file_name} {output_atm_file_name}'
+        hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+
+        datetime_att = t.strftime("%Y-%m-%d-%H000")
+        cmd = f'ncatted -O -a case_t0,global,c,c,\'{datetime_att}\' {output_atm_file_name}'
+        hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+    # --------------------------------------------------------------------------
+    # # Use xarray to add number concentration fields
+    # if 'add_number' not in locals(): add_number = False
+    # if add_number:
+    #     with xr.open_dataset(ofile) as ds:
+    #         ds.load()
+    #         ds['nc'] = xr.zeros_like( ds['qv'] )
+    #         ds['ni'] = xr.zeros_like( ds['qv'] )
+    #         ds['nc'].attrs['long_name'] = 'Specific ice number concentration'
+    #         ds['ni'].attrs['long_name'] = 'Specific liq number concentration'
+    #         ds['nc'].attrs['units'] = 'kg**-1'
+    #         ds['ni'].attrs['units'] = 'kg**-1'
+    ### NOTE - we don't need this as long as the defaults are set properly for 
+    ### each grid in => components/eamxx/cime_config/namelist_defaults_scream.xml
+# ------------------------------------------------------------------------------
+# Print final output file names
+print('\noutput files:')
+for ofile in output_file_list: print(f'  {ofile}')
+print()
+# ------------------------------------------------------------------------------
+if 'combine_daily' not in locals(): combine_daily = False
+if combine_daily:
+    print('\nCombining sub-daily files into daily files...')
+
+    for t in datetime_list:
+
+        hr_datetime = t.strftime("%Y-%m-%d-%H")
+        dy_datetime = t.strftime("%Y-%m-%d")
+
+        hr_file_name = f'{dst_data_root}/HICCUP.nudging_uv_era5.{hr_datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
+        dy_file_name = f'{dst_data_root}/HICCUP.nudging_uv_era5.{dy_datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
+
+        cmd = f'ncks -A --no_tmp_fl {hr_file_name} {dy_file_name} '
+        hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+
+# ------------------------------------------------------------------------------

--- a/template_scripts/SCREAM_process_nudging_data.py
+++ b/template_scripts/SCREAM_process_nudging_data.py
@@ -6,41 +6,77 @@ import os, datetime, pandas as pd
 import xarray as xr
 from hiccup import hiccup_data_class as hdc
 from hiccup import hiccup_state_adjustment as hsa
+from time import perf_counter
+# ------------------------------------------------------------------------------
+''' commands to generate model grid file
+NE=4
+HICCUP_ROOT=/lustre/orion/cli115/proj-shared/hannah6/HICCUP
+GenerateCSMesh --alt --res ${NE} --file ${HICCUP_ROOT}/files_grid/exodus_ne${NE}.g
+GenerateVolumetricMesh --in ${HICCUP_ROOT}/files_grid/exodus_ne${NE}.g --out ${HICCUP_ROOT}/files_grid/exodus_ne${NE}pg2.g --np 2 --uniform
+ConvertMeshToSCRIP --in ${HICCUP_ROOT}/files_grid/exodus_ne${NE}pg2.g --out ${HICCUP_ROOT}/files_grid/scrip_ne${NE}pg2.nc
+'''
+# ------------------------------------------------------------------------------
+''' commands to generate TR bilinear mapping file for online gridding of nudging data
+NE_SRC=4 ; NE_DST=30
+HICCUP_ROOT=/lustre/orion/cli115/proj-shared/hannah6/HICCUP
+SRC_GRID_FILE=${HICCUP_ROOT}/files_grid/scrip_ne${NE_SRC}pg2.nc
+DST_GRID_FILE=${HICCUP_ROOT}/files_grid/scrip_ne${NE_DST}pg2.nc
+MAP_FILE=${HICCUP_ROOT}/files_map/map_ne${NE_SRC}pg2_to_ne${NE_DST}pg2_trbilin.20240201.nc
+ncremap -5 -a trbilin --a2o --src_grd=${SRC_GRID_FILE} --dst_grd=${DST_GRID_FILE} --map_file=${MAP_FILE}
+'''
 # ------------------------------------------------------------------------------
 # Logical flags for controlling what this script will do (comment out to disable)
 verbose = True            # Global verbosity flag
-# unpack_nc_files = True    # unpack data files (convert short to float)
-# create_map_file = True    # grid and map file creation
-# remap_data_horz = True    # horz remap, variable renaming
-# remap_data_vert = True    # vertical remap
-# combine_files   = True    # combine temporary data files and delete
-# add_pressure    = True
+unpack_nc_files = True    # unpack data files (convert short to float)
+create_map_file = True    # grid and map file creation
+remap_data_horz = True    # horz remap, variable renaming
+remap_data_vert = True    # vertical remap
+combine_files   = True    # combine temporary data files and delete
+add_pressure    = True
+adjust_fillval  = True
+add_case_t0     = True
+transpose_dims  = True
+remove_ilev     = True
 combine_daily   = True
 # ------------------------------------------------------------------------------
 
+# bdate_str,edate_str = '2020-01-20 00','2020-01-26 21' # 2024 SCREAM - autocalibration
+bdate_str,edate_str = '2020-01-20 00','2020-01-20 21'
+# bdate_str,edate_str = '2020-01-21 00','2020-01-26 21'
+
 # Create list of date and time 
-beg_date = datetime.datetime.strptime('2006-08-09 00', '%Y-%m-%d %H')
-end_date = datetime.datetime.strptime('2006-08-13 21', '%Y-%m-%d %H')
+beg_date = datetime.datetime.strptime(bdate_str, '%Y-%m-%d %H')
+end_date = datetime.datetime.strptime(edate_str, '%Y-%m-%d %H')
 datetime_list = pd.date_range(beg_date, end_date, freq='3H')
+
+# datetime_list = [ datetime_list[0] ] # use one file for debugging
 
 # local path for grid, map, and data files
 hiccup_root = os.getenv('HOME')+'/HICCUP'
-src_data_root = '/global/cfs/cdirs/m2637/whannah/nudge_data'
-dst_data_root = '/global/cfs/cdirs/m2637/whannah/nudge_data'
+src_data_root = '/lustre/orion/cli115/proj-shared/hannah6/scream_scratch/nudge_data'
+dst_data_root = '/lustre/orion/cli115/proj-shared/hannah6/scream_scratch/nudge_data'
 
 # Specify output atmosphere horizontal grid
-dst_horz_grid = 'ne0np4-saomai-128x8'
+# dst_horz_grid = 'ne4pg2'
+dst_horz_grid = 'ne128pg2'
+# dst_horz_grid = 'ne256pg2'
+# dst_horz_grid = 'ne512pg2'
 
 # Specify output atmosphere vertical grid
 dst_vert_grid,vert_file_name = 'L128',f'{hiccup_root}/files_vert/vert_coord_E3SM_L128.nc'
 
-dst_grid_file = '/global/cfs/cdirs/m2637/jsgoodni/Saomai_2006_ne128x8_lon130E_lat25Npg2.scrip.nc'
-# map_file = '/global/cfs/cdirs/m2637/whannah/'
-
 hdc.target_model = 'EAMXX-nudging'
 hdc.verbose_indent = '  '
 
+ref_date = beg_date.strftime("%Y-%m-%d")
+
 # ------------------------------------------------------------------------------
+def get_nudge_file(datetime):
+    return f'{dst_data_root}/HICCUP.nudging_uv_era5.{datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
+# ------------------------------------------------------------------------------
+timer_start = perf_counter() # start timer for entire script
+# ------------------------------------------------------------------------------
+map_file_created = False
 output_file_list = []
 for t in datetime_list:
 
@@ -49,7 +85,7 @@ for t in datetime_list:
     src_atm_file = f'{src_data_root}/ERA5.atm.{nudge_datetime}:00.nc'
     src_sfc_file = f'{src_data_root}/ERA5.sfc.{nudge_datetime}:00.nc'
 
-    output_atm_file_name = f'{dst_data_root}/HICCUP.nudging_uv_era5.{nudge_datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
+    output_atm_file_name = get_nudge_file(nudge_datetime)
     output_file_list.append(output_atm_file_name)
 
     # Create data class instance
@@ -65,14 +101,20 @@ for t in datetime_list:
                                         ,tmp_dir=dst_data_root
                                         ,verbose=verbose
                                         ,check_input_files=False) # only need U/V
+
     # Print some informative stuff
-    print('\n  Input Files')
-    print(f'    input atm files: {hiccup_data.atm_file}')
-    print(f'    input sfc files: {hiccup_data.sfc_file}')
-    print('\n  Output files')
-    print(f'    output atm file: {output_atm_file_name}')
+    if verbose:
+        print('\n  Input Files')
+        print(f'    input atm files: {hiccup_data.atm_file}')
+        print(f'    input sfc files: {hiccup_data.sfc_file}')
+        print('\n  Output files')
+        print(f'    output atm file: {output_atm_file_name}')
+
     # Get dict of temporary files for each variable
-    file_dict = hiccup_data.get_multifile_dict()
+    # dict_timestamp = datetime.datetime.utcnow().strftime('%Y%m%d')
+    dict_timestamp = nudge_datetime
+    file_dict = hiccup_data.get_multifile_dict(verbose=verbose
+                                              ,timestamp=dict_timestamp)
     # # Specify mapping file
     # hiccup_data.map_file = map_file
     # --------------------------------------------------------------------------
@@ -83,13 +125,21 @@ for t in datetime_list:
     # ------------------------------------------------------------------------------
     # Create grid and mapping files
     if 'create_map_file' not in locals(): create_map_file = False
-    if create_map_file :
-        # Create destination grid description file
+    if create_map_file and not map_file_created:
+        # Create grid description files
         hiccup_data.create_src_grid_file()
-        # specify destination grid file
-        hiccup_data.dst_grid_file = dst_grid_file
+        # hiccup_data.src_grid_file = f'{hiccup_data.grid_dir}/nudge_data/scrip_ERA5_721x1440.nc'
+        hiccup_data.create_dst_grid_file()
+        # make sure we're using the pg2 grid for output
+        hiccup_data.dst_grid_file = hiccup_data.dst_grid_file_pg
         # Create mapping file
         hiccup_data.create_map_file(src_type='FV',dst_type='FV')
+        # save the paths and skip this step for further iterations
+        map_file_created = True
+    else:
+        hiccup_data.src_grid_file = f'{hiccup_data.grid_dir}/scrip_ERA5_721x1440.nc'
+        hiccup_data.dst_grid_file = f'{hiccup_data.grid_dir}/scrip_{dst_horz_grid}.nc'
+        hiccup_data.map_file      = f'{hiccup_data.map_dir}/map_721x1440_to_{dst_horz_grid}.nc'
     # --------------------------------------------------------------------------
     # perform multi-file horizontal remap
     if 'remap_data_horz' not in locals(): remap_data_horz = False
@@ -99,7 +149,8 @@ for t in datetime_list:
         # Rename variables to match what the model expects
         hiccup_data.rename_vars_multifile(file_dict=file_dict)
         # Add time/date information
-        hiccup_data.add_time_date_variables_multifile(file_dict=file_dict)
+        hiccup_data.add_time_date_variables_multifile(file_dict=file_dict
+                                                     ,ref_date=ref_date)
     # --------------------------------------------------------------------------
     # Vertically remap the data
     if 'remap_data_vert' not in locals(): remap_data_vert = False
@@ -120,32 +171,65 @@ for t in datetime_list:
     # Use NCO to add p_mid field and case_t0 attribute
     if 'add_pressure' not in locals(): add_pressure = False
     if add_pressure:
-
         print(hdc.verbose_indent+'\nAdding pressure field to nudging data...')
-
-        cmd = f'ncap2 -O -s \'p_mid[time,lev,ncol]=100000.0*hyam+PS*hybm\' {output_atm_file_name} {output_atm_file_name}'
+        # cmd = f'ncap2 -O -s \'p_mid[time,lev,ncol]=100000.0*hyam+PS*hybm\' {output_atm_file_name} {output_atm_file_name}'
+        cmd = f'ncap2 -O -s \'p_mid[time,ncol,lev]=100000.0*hyam+PS*hybm\' {output_atm_file_name} {output_atm_file_name}'
         hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
-
-        datetime_att = t.strftime("%Y-%m-%d-%H000")
-        cmd = f'ncatted -O -a case_t0,global,c,c,\'{datetime_att}\' {output_atm_file_name}'
+        # add _FillValue attribute
+        cmd = f'ncatted -O -a _FillValue,p_mid,o,d,1e30 {output_atm_file_name}  {output_atm_file_name}'
         hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
     # --------------------------------------------------------------------------
-    # # Use xarray to add number concentration fields
-    # if 'add_number' not in locals(): add_number = False
-    # if add_number:
-    #     with xr.open_dataset(ofile) as ds:
-    #         ds.load()
-    #         ds['nc'] = xr.zeros_like( ds['qv'] )
-    #         ds['ni'] = xr.zeros_like( ds['qv'] )
-    #         ds['nc'].attrs['long_name'] = 'Specific ice number concentration'
-    #         ds['ni'].attrs['long_name'] = 'Specific liq number concentration'
-    #         ds['nc'].attrs['units'] = 'kg**-1'
-    #         ds['ni'].attrs['units'] = 'kg**-1'
-    ### NOTE - we don't need this as long as the defaults are set properly for 
-    ### each grid in => components/eamxx/cime_config/namelist_defaults_scream.xml
+    # Use NCO to add p_mid field and case_t0 attribute
+    if 'adjust_fillval' not in locals(): adjust_fillval = False
+    if adjust_fillval:
+        ds = xr.open_dataset(output_atm_file_name)
+        print()
+        fval_var_list = []
+        mval_var_list = []
+        xval_var_list = []
+        for v in (list(ds.coords)+list(ds.data_vars)):
+            if '_FillValue'    in ds[v].encoding.keys(): fval_var_list.append(v)
+            if 'missing_value' in ds[v].encoding.keys(): mval_var_list.append(v)
+            if 'eulaVlliF_'    in ds[v].attrs.keys():    xval_var_list.append(v) # not sure why this attribute gets added
+            if 'eulaVlliF_'    in ds[v].encoding.keys(): xval_var_list.append(v) # not sure why this attribute gets added
+        # update _FillValue to ensure consistency and a large positive value required by SCREAM
+        if fval_var_list != []:
+            for v in fval_var_list:
+                cmd = f'ncatted -h -O -a _FillValue,{v},o,d,1e30 {output_atm_file_name}  {output_atm_file_name}'
+                hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+        # delete the redundant missing_value attribute from all variables
+        if mval_var_list != []:
+            for v in mval_var_list:
+                cmd = f'ncatted -h -O -a missing_value,{v},d,, {output_atm_file_name}  {output_atm_file_name}'
+                hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+        # fix mangled fill value attribute
+        if xval_var_list != []:
+            for v in xval_var_list:
+                cmd = f'ncatted -h -O -a eulaVlliF_,{v},d,, {output_atm_file_name}  {output_atm_file_name}'
+                hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+    # --------------------------------------------------------------------------
+    # Use NCO to add global attribute case_t0
+    if 'add_case_t0' not in locals(): add_case_t0 = False
+    if add_case_t0:
+        # This is temporary - won't be needed after PR to overhaul time interpolation in SCREAM
+        case_t0 = f'{ref_date}-00000'
+        cmd = f'ncatted -O -a case_t0,global,c,c,\'{case_t0}\' {output_atm_file_name}'
+        hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+    # --------------------------------------------------------------------------
+    if 'transpose_dims' not in locals(): transpose_dims = False
+    if transpose_dims:
+        print(hdc.verbose_indent+'\nTransposing data dimensions...')
+        cmd = f'ncpdq -O --rdr=time,ncol,lev {output_atm_file_name} {output_atm_file_name}'
+        hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+    # --------------------------------------------------------------------------
+    if 'remove_ilev' not in locals(): remove_ilev = False
+    if remove_ilev:
+        print(hdc.verbose_indent+'\nRemoving variables with ilev dimension...')
+        cmd = f'ncks -C -O -x -v ilev,hyai,hybi {output_atm_file_name} {output_atm_file_name}'
+        hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
 # ------------------------------------------------------------------------------
 # Print final output file names
-print('\noutput files:')
+print('\nhourly output files:')
 for ofile in output_file_list: print(f'  {ofile}')
 print()
 # ------------------------------------------------------------------------------
@@ -153,15 +237,52 @@ if 'combine_daily' not in locals(): combine_daily = False
 if combine_daily:
     print('\nCombining sub-daily files into daily files...')
 
+    # build list of daily files and identify old daily files to delete
+    dy_file_list = []
+    dy_datestr_list = []
+    dy_datetime_list = []
     for t in datetime_list:
-
-        hr_datetime = t.strftime("%Y-%m-%d-%H")
         dy_datetime = t.strftime("%Y-%m-%d")
+        # add to list of daily dates (no subdaily dates)
+        if dy_datetime not in dy_datestr_list: 
+            dy_datestr_list.append(dy_datetime)
+            dy_datetime_list.append(t)
+        # check if the daily file already exists
+        dy_file_name = get_nudge_file(dy_datetime)
+        if dy_file_name not in dy_file_list:
+            if os.path.isfile(dy_file_name):
+                dy_file_list.append(dy_file_name)
 
-        hr_file_name = f'{dst_data_root}/HICCUP.nudging_uv_era5.{hr_datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
-        dy_file_name = f'{dst_data_root}/HICCUP.nudging_uv_era5.{dy_datetime}.{dst_horz_grid}.{dst_vert_grid}.nc'
+    # delete old daily files
+    if dy_file_list!=[]:
+        print(hdc.verbose_indent+'removing old daily files...')
+        for dy_file_name in dy_file_list:
+            hdc.run_cmd(f'rm {dy_file_name} ',verbose=True,prefix=hdc.verbose_indent)
+        print()
 
-        cmd = f'ncks -A --no_tmp_fl {hr_file_name} {dy_file_name} '
-        hdc.run_cmd(cmd,verbose=True,prepend_line=False,shell=True)
+    # combine hourly files for each day
+    dy_file_list = []
+    for d in dy_datetime_list:
+        dy_date = d.strftime("%Y-%m-%d")
+        dy_file_name = get_nudge_file(dy_date)
+        dy_file_list.append(dy_file_name)
+        # build list of sub-daily files for this date
+        hr_file_list = []
+        for h in datetime_list:
+            hr_date = h.strftime("%Y-%m-%d")
+            if hr_date==dy_date:
+                hr_datetime = h.strftime("%Y-%m-%d-%H")
+                hr_file_list.append(get_nudge_file(hr_datetime))
+
+        hr_file_list_str = ' '.join(hr_file_list)
+        cmd = f'ncrcat -5 -O -h {hr_file_list_str} {dy_file_name} '
+        hdc.run_cmd(cmd,verbose=True,shell=True,prefix=hdc.verbose_indent)
+
+    print('\noutput files:')
+    for dfile in dy_file_list: print(f'  {dfile}')
+    print()
+# ------------------------------------------------------------------------------
+
+hdc.print_timer(timer_start,caller=f'Total',print_msg=False); print()
 
 # ------------------------------------------------------------------------------

--- a/template_scripts/run_hiccup_batch.nersc.sh
+++ b/template_scripts/run_hiccup_batch.nersc.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-#SBATCH -C knl
+#SBATCH --constraint=cpu
 #SBATCH --account=m3312
-#SBATCH --partition regular
-#SBATCH --time=4:00:00
+#SBATCH --qos=regular
+#SBATCH --time=6:00:00
 #SBATCH --nodes=1
 #SBATCH --mail-user=hannah6@llnl.gov
 #SBATCH --mail-type=END,FAIL
@@ -12,14 +12,21 @@
 # (NOte that NE ~ number of spectral elements on a cube edge, and NE=30 roughly corresponds 1 degree grid)
 # NE=120 ; sbatch --job-name=hiccup_ne$NE --output=logs_slurm/slurm-%x-%j.out --export=NE=$NE ./run_hiccup_batch.rhea.sh
 
+
+# sbatch template_scripts/run_hiccup_batch.nersc.sh
+
+
 # Load the python environment
 source activate hiccup_env
 
 
-VGRID=L120
-time python -u ./create_initial_condition.py --init_date=2008-10-01 --vgrid=$VGRID
+# VGRID=L120
+# time python -u ./create_initial_condition.py --init_date=2008-10-01 --vgrid=$VGRID
+
+# sbatch template_scripts/run_hiccup_batch.nersc.sh
+time python -u custom_scripts/2024.SCREAM_autocalibration.process_nudging_data.py
 
 # Notes:
-# "time" is added to add the execution time to the log file.
+# "time" is used here to print the execution time to the end of log file.
 # the "-u" option allows the log file to update in real time 
 # which is useful for montioring the batch job.

--- a/test_scripts/get_test_data.ERA5.py
+++ b/test_scripts/get_test_data.ERA5.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# Script for downloading ERA5 pressure level and surface data
+# links to CDS web interface:
+#   https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels
+#   https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels
+# A list of available variables can also be found in the ERA5 documentation:
+#   https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation
+
+import os
+import cdsapi
+server = cdsapi.Client()
+
+get_atm = True
+get_sfc = True
+get_lnd = False
+
+### single date
+yr_list,mn_list,dy_list = ['2008'],['10'],['01']
+
+### list of one date acros many years
+# yr_list = [str(y+2000) for y in range(8,19)]
+# mn_list = ['10']*len(yr_list)
+# dy_list = ['01']*len(yr_list)
+
+# time_list = ['00:00','03:00','06:00','09:00','12:00','15:00','18:00','21:00']
+time_list = ['00:00']*len(yr_list)
+
+# # All available pressure levels
+# lev = [  '1',  '2',  '3',  '5',  '7', '10', '20', '30', '50', '70'
+#       ,'100','125','150','175','200','225','250','300','350','400'
+#       ,'450','500','550','600','650','700','750','775','800','825'
+#       ,'850','875','900','925','950','975','1000']
+
+# Small level set for testing
+lev = [ '50','100','150','200','300','400','500','600'
+      ,'700','750','800','850','900','950','1000']
+
+output_path = os.getenv('PWD')+'/test_data'
+
+output_file_plv = f'{output_path}/HICCUP_TEST.ERA5.atm.nc'
+output_file_sfc = output_file_plv.replace('atm.nc','sfc.nc')
+output_file_lnd = output_file_plv.replace('atm.nc','lnd.nc')
+
+
+for i in range(len(yr_list)):
+  yr = yr_list[i]
+  mn = mn_list[i]
+  dy = dy_list[i]
+  time = time_list[i]
+
+  # output_file_plv = output_path+f'ERA5.atm.{yr_list[0]}-{mn_list[0]}-{dy_list[0]}.nc'
+  output_file_plv = output_path+f'/ERA5.atm.{yr}-{mn}-{dy}.nc'
+  output_file_mlv = output_file_plv.replace('.atm.','.mlev.')
+  output_file_sfc = output_file_plv.replace('.atm.','.sfc.')
+  output_file_lnd = output_file_plv.replace('.atm.','.lnd.')
+
+  #-------------------------------------------------------------------------------
+  # atmossphere pressure level data
+  if get_atm:
+      server.retrieve('reanalysis-era5-pressure-levels',{
+          'product_type'  : 'reanalysis',
+          'pressure_level': lev,
+          # 'time'          : time_list,
+          # 'day'           : dy_list,
+          # 'month'         : mn_list,
+          # 'year'          : yr_list,
+          'time'          : time,
+          'day'           : dy,
+          'month'         : mn,
+          'year'          : yr,
+          'format'        : 'netcdf',
+          'variable'      : ['temperature'
+                            ,'specific_humidity'
+                            ,'geopotential'
+                            ,'u_component_of_wind'
+                            ,'v_component_of_wind'
+                            ,'ozone_mass_mixing_ratio'
+                            ,'specific_cloud_ice_water_content'
+                            ,'specific_cloud_liquid_water_content'
+                            ],
+      }, output_file_plv)
+      ### not sure why I added this...?
+      # server.retrieve('reanalysis-era5-complete',{
+      #     'product_type'  : 'reanalysis',
+      #     # 'pressure_level': lev,
+      #     'levtype': 'ml', 
+      #     'time'          : time_list,
+      #     'day'           : dy_list,
+      #     'month'         : mn_list,
+      #     'year'          : yr_list,
+      #     'format'        : 'netcdf',
+      #     'variable'      : ['temperature'],
+      # }, output_file_mlv)
+  #-------------------------------------------------------------------------------
+  # surface data
+  if get_sfc:
+      server.retrieve('reanalysis-era5-single-levels',{
+          'product_type'  : 'reanalysis',
+          # 'time'          : time_list,
+          # 'day'           : dy_list,
+          # 'month'         : mn_list,
+          # 'year'          : yr_list,
+          'time'          : time,
+          'day'           : dy,
+          'month'         : mn,
+          'year'          : yr,
+          'format'        : 'netcdf',
+          'variable'      : ['surface_pressure'
+                            ,'skin_temperature'
+                            ,'sea_surface_temperature'
+                            ,'2m_temperature'
+                            ,'soil_temperature_level_1'
+                            ,'soil_temperature_level_2'
+                            ,'soil_temperature_level_3'
+                            ,'soil_temperature_level_4'
+                            # ,'leaf_area_index_high_vegetation'
+                            # ,'leaf_area_index_low_vegetation'
+                            # ,'skin_reservoir_content'
+                            # ,'snow_albedo'
+                            # ,'snow_density'
+                            ,'snow_depth'
+                            ,'temperature_of_snow_layer'
+                            # ,'volumetric_soil_water_layer_1'
+                            # ,'volumetric_soil_water_layer_2'
+                            # ,'volumetric_soil_water_layer_3'
+                            # ,'volumetric_soil_water_layer_4'
+                            # ,'orography'
+                            ,'geopotential'
+                            ,'sea_ice_cover'
+                            ],
+      }, output_file_sfc)
+  #-------------------------------------------------------------------------------
+  # land model data
+  if get_lnd:
+      server.retrieve('reanalysis-era5-land',{
+              'format': 'netcdf',
+              'variable': [
+                  'leaf_area_index_high_vegetation'
+                  ,'leaf_area_index_low_vegetation'
+                  ,'skin_reservoir_content'
+                  ,'snow_albedo'
+                  ,'snow_cover'
+                  ,'snow_density'
+                  ,'snow_depth'
+                  ,'snow_depth_water_equivalent'
+                  ,'soil_temperature_level_1'
+                  ,'soil_temperature_level_2'
+                  ,'soil_temperature_level_3'
+                  ,'soil_temperature_level_4'
+                  ,'temperature_of_snow_layer'
+                  ,'volumetric_soil_water_layer_1'
+                  ,'volumetric_soil_water_layer_2'
+                  ,'volumetric_soil_water_layer_3'
+                  ,'volumetric_soil_water_layer_4'
+              ],
+              # 'time'          : time_list,
+              # 'day'           : dy_list,
+              # 'month'         : mn_list,
+              # 'year'          : yr_list,
+              'time'          : time,
+              'day'           : dy,
+              'month'         : mn,
+              'year'          : yr,
+      },output_file_lnd)
+  #-------------------------------------------------------------------------------

--- a/test_scripts/get_test_data.NOAA.py
+++ b/test_scripts/get_test_data.NOAA.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# Script for downloading NOAA SST and sea ice data for hindcasts
+# Only one year is downloaded at a time
+# for more information about the dataset:
+# https://climatedataguide.ucar.edu/climate-data/sst-data-noaa-high-resolution-025x025-blended-analysis-daily-sst-and-ice-oisstv2
+
+import ftplib
+import os
+
+yr_list = [2008]
+
+host = 'ftp.cdc.noaa.gov'
+path = 'Datasets/noaa.oisst.v2.highres/'
+
+output_path = os.getenv('HOME')+'/HICCUP/test_data'
+os.makedirs(output_path, exist_ok=True)  # create output_path if it doesn't exist
+
+for year in yr_list:
+
+  sst_file_name = f'sst.day.mean.{year}.nc'
+  ice_file_name = f'icec.day.mean.{year}.nc'
+
+  ftp = ftplib.FTP(host)
+  ftp.login()
+  ftp.cwd(path)
+
+  for file_name in [sst_file_name, ice_file_name]:
+    with open(f'{output_path}/{file_name}', 'wb') as file_pointer:
+      print(f'Retrieving file: {file_name}')
+      ftp.retrbinary(f'RETR {file_name}', file_pointer.write)
+
+  ftp.quit()
+
+print('\ndone.')

--- a/test_scripts/remap.test_data.NOAA.py
+++ b/test_scripts/remap.test_data.NOAA.py
@@ -8,11 +8,11 @@ regrid_data = True
 # ------------------------------------------------------------------------------
 
 # SST data
-sst_src_file_name = 'data_scratch/sst.day.mean.2008.nc'
+sst_src_file_name = 'test_data/sst.day.mean.2008.nc'
 sst_dst_file_name = 'test_data/HICCUP_TEST.NOAA.sst.nc'
 
 # sea-ice data
-ice_src_file_name = 'data_scratch/icec.day.mean.2008.nc'
+ice_src_file_name = 'test_data/icec.day.mean.2008.nc'
 ice_dst_file_name = 'test_data/HICCUP_TEST.NOAA.ice.nc'
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This includes various updates to support the generation of nudging data for SCREAM simulations.

One quirk of this workflow is that a global attribute "case_t0" is required to be consistent across all nudging data files, but this requirement will be removed by this PR on the SCREAM repo:
https://github.com/E3SM-Project/scream/pull/2635

Also, the template script currently uses a hacky way to permute the dimensions, which must be (time,ncol,lev). This task should be incorporated into the hiccup methods, either in a new routine or in one of the existing routines based on the target model. I'd prefer the latter approach, but I'm not sure how to do it yet.  