### PR TITLE
update state adjustments

### DIFF
--- a/hiccup/hiccup.py
+++ b/hiccup/hiccup.py
@@ -22,8 +22,10 @@ default_tmp_dir     = './files_tmp'
 # Global verbosity default
 hiccup_verbose = False
 verbose_indent = ''
+
 hdc.hiccup_verbose = hiccup_verbose
 hdc.verbose_indent = verbose_indent
+
 hu.hiccup_verbose = hiccup_verbose
 hu.verbose_indent = verbose_indent
 

--- a/hiccup/hiccup_state_adjustment.py
+++ b/hiccup/hiccup_state_adjustment.py
@@ -331,7 +331,6 @@ def remove_supersaturation( ds, hybrid_lev=False, pressure_var_name='plev',
 
   # Calculate saturation specific humidity
   qv_sat = calculate_qv_sat_liq(ds['T'],pressure)
-  qv_sat.compute()
   
   if debug:
     print(); print_stat(qv_sat,name='qv_sat in remove_supersaturation')
@@ -340,12 +339,8 @@ def remove_supersaturation( ds, hybrid_lev=False, pressure_var_name='plev',
   # that can occur in the upper stratosphere and mesosphere
   qv_sat.values = xr.where(qv_sat.values>=0.0,qv_sat,1.0)
 
-  ds['Q'].compute()
-  qv_sat.compute()
-
   # Calculate relative humidity for limiter
   rh = ds['Q'] / qv_sat
-  rh.compute()
 
   if debug:
     print(); print_stat(rh,name='rh in remove_supersaturation')
@@ -354,8 +349,8 @@ def remove_supersaturation( ds, hybrid_lev=False, pressure_var_name='plev',
   tmp_attrs = ds['Q'].attrs
 
   # Apply limiter conditions
-  ds['Q'].values = xr.where(rh.values>1.,qv_sat,ds['Q']).compute()
-  ds['Q'].values = xr.where(rh.values<0.,qv_min,ds['Q']).compute()
+  ds['Q'] = xr.where(rh.values>1.,qv_sat,ds['Q'])
+  ds['Q'] = xr.where(rh.values<0.,qv_min,ds['Q'])
   
   # restore attributes
   ds['Q'].attrs = tmp_attrs
@@ -374,12 +369,9 @@ def adjust_cld_wtr( ds, verbose=None ):
   if verbose is None : verbose = default_verbose
   if verbose: print('\nAdjusting cloud water...')
 
-  if 'CLDLIQ' in ds.data_vars:
-    ds['CLDLIQ'].values = xr.where(ds['CLDLIQ'].values>=0
-                                  ,ds['CLDLIQ'], 0. ).compute()
-  if 'CLDICE' in ds.data_vars:
-    ds['CLDICE'].values = xr.where(ds['CLDICE'].values>=0
-                                  ,ds['CLDICE'], 0. ).compute()
+  for var in ['CLDLIQ','CLDICE']:
+    if var in ds.data_vars: ds[var].values = xr.where( ds[var].values>=0, ds[var], 0. )
+
   return
 
 #-------------------------------------------------------------------------------

--- a/test_scripts/test.ATM_from_ERA5.py
+++ b/test_scripts/test.ATM_from_ERA5.py
@@ -16,18 +16,18 @@ data_tmp = '/global/cfs/projectdirs/m3312/whannah/HICCUP/test_data_tmp'
 
 os.makedirs(data_tmp, exist_ok=True)  # create temporary output data path if it doesn't exist
 
-dst_horz_grid = 'ne30np4'
+dst_horz_grid = 'ne30np4' # ne30np4 / ne120np4 / ne512np4
 
 dst_vert_grid ='L80'; vert_file_name = f'{hiccup_root}/files_vert/L80_for_E3SMv3.nc'
 
 # Specify output file names
 output_atm_file_name = f'{data_tmp}/HICCUP_TEST_OUTPUT.atm_era5.{dst_horz_grid}.{dst_vert_grid}.nc'
 
-dst_horz_grid=='ne30np4' : topo_file = f'{data_root}/USGS-gtopo30_ne30np4_16xdel2-PFC-consistentSGH.nc'
+if dst_horz_grid=='ne30np4' : topo_file = f'{data_root}/USGS-gtopo30_ne30np4_16xdel2-PFC-consistentSGH.nc'
 # use topo files from the inputdata repo for testing other grids
 din_loc_root = '/global/cfs/cdirs/e3sm/inputdata' # NERSC
-dst_horz_grid=='ne120np4': topo_file = f'{din_loc_root}/atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc'
-dst_horz_grid=='ne512np4': topo_file = f'{din_loc_root}/atm/cam/topo/USGS-gtopo30_ne512np4pg2_x6t_20230404.nc'
+if dst_horz_grid=='ne120np4': topo_file = f'{din_loc_root}/atm/cam/topo/USGS-gtopo30_ne120np4pg2_16xdel2.nc'
+if dst_horz_grid=='ne512np4': topo_file = f'{din_loc_root}/atm/cam/topo/USGS-gtopo30_ne512np4pg2_x6t_20230404.nc'
 
 # Create data class instance, which includes xarray file dataset objects
 # and variable name dictionaries for mapping between naming conventions.
@@ -52,6 +52,7 @@ print(f'    input sfc files: {hiccup_data.sfc_file}')
 print(f'    input topo file: {hiccup_data.topo_file}')
 print('\n  Output files')
 print(f'    output atm file: {output_atm_file_name}')
+print()
 
 # Get dict of temporary files for each variable
 file_dict = hiccup_data.get_multifile_dict(timestamp=999)
@@ -105,9 +106,6 @@ hiccup_data.atmos_state_adjustment_multifile(file_dict=file_dict)
 # Combine and delete temporary files
 hiccup_data.combine_files(file_dict=file_dict,delete_files=True,
                           output_file_name=output_atm_file_name)
-
-# hiccup_data.combine_files(file_dict=file_dict,delete_files=False,dtype='float64',output_file_name=output_atm_file_name)
-# hiccup_data.combine_files(file_dict=file_dict,delete_files=False,dtype='float32',output_file_name=output_atm_file_name)
 
 # Clean up the global attributes of the file
 hiccup_data.clean_global_attributes(file_name=output_atm_file_name)


### PR DESCRIPTION
The main change here is to remove the use of ".compute()" in the state adjustment routines. I've left the compute calls in the topo adjustment routine for now. I noticed that the state adjustment section took the longest out of everything when testing large grids such as ne120 and ne512, which seemed odd to me. This change brings the cost down a bit, although it is still notable. I also changed the default chunking strategy based on some tests with ne30 and ne120 on NERSC Perlmutter.