### PR TITLE
create hiccup_vertical_remap.py

### DIFF
--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -73,7 +73,7 @@ def _compute_output_pressure(ds_vert, ps, out_lev_name):
   ps must already be aligned with the input dataset's non-vertical dims
   """
   if not {'hyam','hybm'}.issubset(ds_vert.variables.keys()):
-    raise ValueError('output_vertical_grid_file must contain hyam and hybm')
+    raise ValueError('ds_vert must contain hyam and hybm')
   p0 = ds_vert['P0'] if 'P0' in ds_vert.variables else _DEFAULT_P0
   hyam = ds_vert['hyam']
   hybm = ds_vert['hybm']
@@ -147,7 +147,8 @@ def _remap_field(field, p_in, p_out, in_lev_name, out_lev_name, mode, extrap):
 def remap_vertical_py(input_file, output_file, vert_file,
                       ps_name='PS', var_list=None, lev_name='lev',
                       mode='log_pressure', extrap='constant',
-                      chunks=None, verbose=False):
+                      chunks=None, nc_output_format='NETCDF4',
+                      verbose=False):
   """
   vertically remap fields in input_file onto the hybrid grid defined by vert_file
   and write the result to output_file
@@ -236,7 +237,7 @@ def remap_vertical_py(input_file, output_file, vert_file,
     if out_lev_name != out_lev_name_native:
       ds_out = ds_out.rename({out_lev_name: out_lev_name_native})
 
-    ds_out.to_netcdf(tmp_file, mode='w')
+    ds_out.to_netcdf(tmp_file, mode='w', format=nc_output_format)
 
   if same_in_out:
     os.replace(tmp_file, output_file)

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -1,0 +1,234 @@
+# -------------------------------------------------------------------------------------------------
+# Pure-Python vertical remap utilities for HICCUP
+#
+# Replaces NCO's `ncremap --vrt_fl=...` with an xarray + numpy implementation that streams
+# columns through dask, so memory does not blow up on large unstructured grids (ne1024, etc.).
+# Top-level entry point is `remap_vertical_py()`; the `_py` suffix disambiguates from the
+# pre-existing NCO-based `remap_vertical()` method on `hiccup_data` (which we keep around as
+# a fallback). The module is intentionally free of `hiccup_data` coupling so it can be unit
+# tested in isolation.
+# -------------------------------------------------------------------------------------------------
+import os
+import numpy as np
+import xarray as xr
+
+from hiccup.hiccup_utilities import tcolor
+
+# default reference pressure (Pa); used only when neither input nor target file carries P0
+_DEFAULT_P0 = 1.0e5
+
+# variables that describe the vertical grid itself; never remapped, always pulled from
+# the target vert_file and copied through verbatim
+_HYBRID_COEF_VARS = ('hyam', 'hybm', 'hyai', 'hybi', 'P0')
+
+# ---------------------------------------------------------------------------
+# pressure-on-grid helpers
+# ---------------------------------------------------------------------------
+def _compute_input_pressure(ds, lev_name, ps_name):
+  """
+  return an xarray.DataArray of pressure on the source vertical grid
+  detects three layouts in priority order:
+    1. hybrid sigma-pressure with PS  (EAM / EAMxx / post-rename ERA5 hybrid)
+    2. ECMWF IFS hybrid with lnsp     (raw ERA5 model levels)
+    3. pure pressure levels           (ERA5 plev / pressure_level after rename to Pa)
+  """
+  variables = set(ds.variables.keys())
+  hybrid_pa = {'hyam','hybm'}.issubset(variables)
+
+  if hybrid_pa and ps_name in variables:
+    # EAM / EAMxx hybrid: p = hyam*P0 + hybm*PS
+    p0 = ds['P0'] if 'P0' in variables else _DEFAULT_P0
+    return ds['hyam']*p0 + ds['hybm']*ds[ps_name]
+
+  if hybrid_pa and 'lnsp' in variables:
+    # ECMWF IFS layout: hyam already in Pa, surface pressure stored as ln(ps)
+    ps = np.exp(ds['lnsp'].squeeze(drop=True))
+    return ds['hyam'] + ds['hybm']*ps
+
+  if lev_name in ds.coords or lev_name in ds.variables:
+    # pure pressure levels - broadcast 1D plev to a DataArray on lev_name
+    return ds[lev_name].astype('float64')
+
+  raise ValueError(
+    f'cannot infer source vertical grid for lev_name={lev_name!r}, ps_name={ps_name!r}; '
+    f'expected hybrid (hyam,hybm,{ps_name}) or pressure-level coordinate'
+  )
+
+# ---------------------------------------------------------------------------
+def _compute_output_pressure(ds_vert, ps, out_lev_name):
+  """
+  return pressure on the target hybrid grid: p = hyam*P0 + hybm*PS
+  ps must already be aligned with the input dataset's non-vertical dims
+  """
+  if not {'hyam','hybm'}.issubset(ds_vert.variables.keys()):
+    raise ValueError('output_vertical_grid_file must contain hyam and hybm')
+  p0 = ds_vert['P0'] if 'P0' in ds_vert.variables else _DEFAULT_P0
+  hyam = ds_vert['hyam']
+  hybm = ds_vert['hybm']
+  # ensure hybrid coefs use the canonical output lev dim name
+  if hyam.dims[0] != out_lev_name:
+    hyam = hyam.rename({hyam.dims[0]: out_lev_name})
+    hybm = hybm.rename({hybm.dims[0]: out_lev_name})
+  return hyam*p0 + hybm*ps
+
+# ---------------------------------------------------------------------------
+# per-column interpolation kernel
+# ---------------------------------------------------------------------------
+def _interp_column(p_target, p_source, f_source, mode='log_pressure',
+                   extrap='constant'):
+  """
+  interpolate a single column from p_source -> p_target
+  - mode:    'log_pressure' (default) or 'linear_pressure'
+  - extrap:  'constant' (clamp, np.interp default) or 'linear' (slope from end pair)
+  np.interp requires monotonically increasing xp; we sort defensively per column
+  """
+  if mode == 'log_pressure':
+    x  = np.log(p_target)
+    xp = np.log(p_source)
+  else:
+    x, xp = p_target, p_source
+
+  order = np.argsort(xp)
+  xp = xp[order]
+  fp = f_source[order]
+
+  y = np.interp(x, xp, fp)
+
+  if extrap == 'linear':
+    left = x < xp[0]
+    if left.any():
+      slope = (fp[1] - fp[0]) / (xp[1] - xp[0])
+      y = np.where(left, fp[0] + (x - xp[0])*slope, y)
+    right = x > xp[-1]
+    if right.any():
+      slope = (fp[-1] - fp[-2]) / (xp[-1] - xp[-2])
+      y = np.where(right, fp[-1] + (x - xp[-1])*slope, y)
+
+  return y
+
+# ---------------------------------------------------------------------------
+def _remap_field(field, p_in, p_out, in_lev_name, out_lev_name, mode, extrap):
+  """
+  remap a single xarray.DataArray from in_lev_name -> out_lev_name
+  driven by xarray.apply_ufunc with vectorize=True so dask can parallelize over columns
+  """
+  out_dtype = field.dtype if np.issubdtype(field.dtype, np.floating) else np.float64
+
+  def _kernel(p_t, p_s, f_s):
+    return _interp_column(p_t, p_s, f_s, mode=mode, extrap=extrap).astype(out_dtype)
+
+  result = xr.apply_ufunc(
+    _kernel,
+    p_out, p_in, field,
+    input_core_dims=[[out_lev_name], [in_lev_name], [in_lev_name]],
+    output_core_dims=[[out_lev_name]],
+    vectorize=True,
+    dask='parallelized',
+    output_dtypes=[out_dtype],
+  )
+  result.attrs = dict(field.attrs)
+  return result
+
+# ---------------------------------------------------------------------------
+# top-level entry point
+# ---------------------------------------------------------------------------
+def remap_vertical_py(input_file, output_file, vert_file,
+                      ps_name='PS', var_list=None, lev_name='lev',
+                      mode='log_pressure', extrap='constant',
+                      chunks=None, verbose=False):
+  """
+  vertically remap fields in input_file onto the hybrid grid defined by vert_file
+  and write the result to output_file
+  parameters
+    input_file   path to source dataset (must contain ps_name and lev_name)
+    output_file  path to write remapped dataset
+    vert_file    target vertical grid file (must contain hyam, hybm; P0 optional)
+    ps_name      name of surface pressure variable in input_file (default 'PS')
+    var_list     list of variables to remap; if None, remap every var with lev_name in dims
+    lev_name     name of source vertical dim (default 'lev')
+    mode         'log_pressure' (default) or 'linear_pressure'
+    extrap       'constant' (default, clamp) or 'linear' (slope from end pair)
+    chunks       dict passed to xr.open_dataset; lev_name is forced to -1 if absent
+    verbose      print progress
+  """
+  if mode not in ('log_pressure','linear_pressure'):
+    raise ValueError(f'mode must be log_pressure or linear_pressure, got {mode!r}')
+  if extrap not in ('constant','linear'):
+    raise ValueError(f'extrap must be constant or linear, got {extrap!r}')
+
+  same_in_out = os.path.abspath(input_file) == os.path.abspath(output_file)
+  tmp_file = output_file + '.vrt_tmp.nc' if same_in_out else output_file
+
+  if chunks is None:
+    chunks = {lev_name: -1}
+  else:
+    chunks = dict(chunks)
+    chunks[lev_name] = -1
+
+  if verbose:
+    print(f'{tcolor.GREEN}  vertical remap: {input_file} -> {output_file}{tcolor.ENDC}')
+
+  with xr.open_dataset(input_file, chunks=chunks) as ds_in, \
+       xr.open_dataset(vert_file) as ds_vert:
+
+    if ps_name not in ds_in.variables:
+      raise ValueError(f'input_file does not contain surface pressure variable {ps_name!r}')
+
+    out_lev_name_native = ds_vert['hyam'].dims[0]
+    # if source and target use the same dim name, rename target internally so apply_ufunc
+    # can tell them apart; we restore the native name at the end via the output dataset
+    out_lev_name = out_lev_name_native
+    if out_lev_name == lev_name:
+      out_lev_name = f'{lev_name}_target'
+      ds_vert = ds_vert.rename({out_lev_name_native: out_lev_name})
+
+    p_in  = _compute_input_pressure(ds_in, lev_name, ps_name)
+    p_out = _compute_output_pressure(ds_vert, ds_in[ps_name], out_lev_name)
+
+    # decide which fields get remapped; never remap the hybrid coefficients themselves -
+    # those describe the vertical grid and are pulled from vert_file
+    if var_list is None:
+      var_list = [v for v in ds_in.data_vars
+                  if lev_name in ds_in[v].dims and v not in _HYBRID_COEF_VARS]
+    else:
+      var_list = [v for v in var_list
+                  if v in ds_in.data_vars and v not in _HYBRID_COEF_VARS]
+
+    # build output dataset: target hybrid coefs from vert_file, plus passthrough vars
+    ds_out = xr.Dataset()
+    for v in _HYBRID_COEF_VARS:
+      if v in ds_vert.variables:
+        ds_out[v] = ds_vert[v]
+    if ps_name in ds_in.variables:
+      ds_out[ps_name] = ds_in[ps_name]
+
+    # passthrough: any var without the source lev dim that isn't already in ds_out
+    for v in ds_in.data_vars:
+      if v in ds_out.variables: continue
+      if v in var_list:         continue
+      if lev_name not in ds_in[v].dims:
+        ds_out[v] = ds_in[v]
+
+    # remap each field
+    for v in var_list:
+      if lev_name not in ds_in[v].dims:
+        # caller asked for a field that isn't on the vertical grid; copy it through
+        ds_out[v] = ds_in[v]
+        continue
+      if verbose: print(f'    remapping {v}')
+      ds_out[v] = _remap_field(ds_in[v], p_in, p_out, lev_name, out_lev_name, mode, extrap)
+
+    # carry over global attrs and coords that aren't tied to the source vertical dim
+    ds_out.attrs = dict(ds_in.attrs)
+
+    # restore the native target lev dim name if we renamed it to avoid collision
+    if out_lev_name != out_lev_name_native:
+      ds_out = ds_out.rename({out_lev_name: out_lev_name_native})
+
+    ds_out.to_netcdf(tmp_file, mode='w')
+
+  if same_in_out:
+    os.replace(tmp_file, output_file)
+
+  return
+# -------------------------------------------------------------------------------------------------

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -177,7 +177,10 @@ def remap_vertical_py(input_file, output_file, vert_file,
     lev_name     name of source vertical dim (default 'lev')
     mode         'log_pressure' (default) or 'linear_pressure'
     extrap       'constant' (default, clamp) or 'linear' (slope from end pair)
-    chunks       dict passed to xr.open_dataset; lev_name is forced to -1 if absent
+    chunks       dict passed to xr.open_dataset; lev_name is forced to -1 (full
+                 column required for interp). When None (default), every non-lev
+                 dim is set to 'auto' so dask picks reasonable chunk sizes for
+                 large unstructured grids; pass an explicit dict to override
     nc_output_format  netCDF format string passed through to xarray's to_netcdf()
                       (default 'NETCDF4'); set to 'NETCDF3_64BIT' etc. when downstream
                       tools require an older format
@@ -191,8 +194,13 @@ def remap_vertical_py(input_file, output_file, vert_file,
   same_in_out = os.path.abspath(input_file) == os.path.abspath(output_file)
   tmp_file = output_file + '.vrt_tmp.nc' if same_in_out else output_file
 
+  # build chunks: lev_name is always forced to -1 (full column needed for interp);
+  # when chunks is None, default every other dim to dask 'auto' so horizontal/time
+  # axes get reasonable chunk sizes instead of one giant chunk per dim
   if chunks is None:
-    chunks = {lev_name: -1}
+    with xr.open_dataset(input_file) as _ds_peek:
+      chunks = {d: 'auto' for d in _ds_peek.dims}
+    chunks[lev_name] = -1
   else:
     chunks = dict(chunks)
     chunks[lev_name] = -1

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -112,7 +112,9 @@ def _interp_column(p_target, p_source, f_source, mode='log_pressure',
 
   y = np.interp(x, xp, fp)
 
-  if extrap == 'linear':
+  # linear extrapolation needs a slope from the last two source points; fall back
+  # to constant (np.interp's clamp) when the column has fewer than 2 levels
+  if extrap == 'linear' and xp.size >= 2:
     left = x < xp[0]
     if left.any():
       slope = (fp[1] - fp[0]) / (xp[1] - xp[0])
@@ -239,6 +241,11 @@ def remap_vertical_py(input_file, output_file, vert_file,
     for v in _HYBRID_COEF_VARS:
       if v in ds_vert.variables:
         ds_out[v] = ds_vert[v]
+    # always carry P0 in the output so the file is self-describing - if vert_file
+    # didn't provide one, record the default that was used in the pressure calc
+    if 'P0' not in ds_out.variables:
+      ds_out['P0'] = xr.DataArray(np.float64(_DEFAULT_P0),
+                                  attrs={'long_name': 'reference pressure', 'units': 'Pa'})
     ds_out[ps_name] = ps
 
     # passthrough: any var without the source lev dim that isn't already in ds_out

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -24,16 +24,22 @@ _HYBRID_COEF_VARS = ('hyam', 'hybm', 'hyai', 'hybi', 'P0')
 # ---------------------------------------------------------------------------
 # pressure-on-grid helpers
 # ---------------------------------------------------------------------------
-def _resolve_surface_pressure(ds, ps_name):
+def _resolve_surface_pressure(ds, ps_name, lev_name='lev'):
   """
   return surface pressure as an xarray.DataArray named ps_name
   prefers ds[ps_name]; falls back to exp(ds['lnsp']) for ECMWF IFS layout
   raises ValueError if neither is available
+  for the lnsp path, drops only the singleton vertical dim (lev_name) when
+  present - using a blanket squeeze() would also strip a singleton time dim
+  and misalign PS with the rest of the dataset for single-timestep inputs
   """
   if ps_name in ds.variables:
     return ds[ps_name]
   if 'lnsp' in ds.variables:
-    return np.exp(ds['lnsp'].squeeze(drop=True)).rename(ps_name)
+    lnsp = ds['lnsp']
+    if lev_name in lnsp.dims:
+      lnsp = lnsp.isel({lev_name: 0}, drop=True)
+    return np.exp(lnsp).rename(ps_name)
   raise ValueError(
     f'input_file must contain surface pressure as {ps_name!r} or as lnsp'
   )
@@ -198,7 +204,7 @@ def remap_vertical_py(input_file, output_file, vert_file,
        xr.open_dataset(vert_file) as ds_vert:
 
     # resolve surface pressure once (handles both PS and IFS lnsp layouts)
-    ps = _resolve_surface_pressure(ds_in, ps_name)
+    ps = _resolve_surface_pressure(ds_in, ps_name, lev_name=lev_name)
 
     out_lev_name_native = ds_vert['hyam'].dims[0]
     # if source and target use the same dim name, rename target internally so apply_ufunc

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -152,16 +152,29 @@ def remap_vertical_py(input_file, output_file, vert_file,
   """
   vertically remap fields in input_file onto the hybrid grid defined by vert_file
   and write the result to output_file
+
+  supported source layouts (auto-detected):
+    - EAM / EAMxx hybrid:  hyam, hybm, P0, and ps_name present
+    - ECMWF IFS hybrid:    hyam (in Pa), hybm, and lnsp present (no P0)
+    - pure pressure level: only the lev_name coordinate (e.g. ERA5 plev in Pa)
+  surface pressure is taken from ps_name when available, else derived as exp(lnsp);
+  in either case the resolved value is written to the output as ps_name
+
   parameters
-    input_file   path to source dataset (must contain ps_name and lev_name)
+    input_file   path to source dataset; must contain lev_name plus a recognized layout
+                 (see above) and either ps_name or lnsp for surface pressure
     output_file  path to write remapped dataset
     vert_file    target vertical grid file (must contain hyam, hybm; P0 optional)
-    ps_name      name of surface pressure variable in input_file (default 'PS')
+    ps_name      name of surface pressure variable in input_file (default 'PS');
+                 also the name used for surface pressure in the output
     var_list     list of variables to remap; if None, remap every var with lev_name in dims
     lev_name     name of source vertical dim (default 'lev')
     mode         'log_pressure' (default) or 'linear_pressure'
     extrap       'constant' (default, clamp) or 'linear' (slope from end pair)
     chunks       dict passed to xr.open_dataset; lev_name is forced to -1 if absent
+    nc_output_format  netCDF format string passed through to xarray's to_netcdf()
+                      (default 'NETCDF4'); set to 'NETCDF3_64BIT' etc. when downstream
+                      tools require an older format
     verbose      print progress
   """
   if mode not in ('log_pressure','linear_pressure'):

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -24,34 +24,46 @@ _HYBRID_COEF_VARS = ('hyam', 'hybm', 'hyai', 'hybi', 'P0')
 # ---------------------------------------------------------------------------
 # pressure-on-grid helpers
 # ---------------------------------------------------------------------------
-def _compute_input_pressure(ds, lev_name, ps_name):
+def _resolve_surface_pressure(ds, ps_name):
+  """
+  return surface pressure as an xarray.DataArray named ps_name
+  prefers ds[ps_name]; falls back to exp(ds['lnsp']) for ECMWF IFS layout
+  raises ValueError if neither is available
+  """
+  if ps_name in ds.variables:
+    return ds[ps_name]
+  if 'lnsp' in ds.variables:
+    return np.exp(ds['lnsp'].squeeze(drop=True)).rename(ps_name)
+  raise ValueError(
+    f'input_file must contain surface pressure as {ps_name!r} or as lnsp'
+  )
+
+# ---------------------------------------------------------------------------
+def _compute_input_pressure(ds, lev_name, ps):
   """
   return an xarray.DataArray of pressure on the source vertical grid
-  detects three layouts in priority order:
-    1. hybrid sigma-pressure with PS  (EAM / EAMxx / post-rename ERA5 hybrid)
-    2. ECMWF IFS hybrid with lnsp     (raw ERA5 model levels)
-    3. pure pressure levels           (ERA5 plev / pressure_level after rename to Pa)
+  detects three layouts:
+    1. EAM / EAMxx hybrid: hyam, hybm, P0 present -> p = hyam*P0 + hybm*ps
+    2. ECMWF IFS hybrid:   hyam in Pa, lnsp present (no P0) -> p = hyam + hybm*ps
+    3. pure pressure levels: only the lev coord -> p = ds[lev_name]
+  ps must be the resolved surface pressure DataArray (see _resolve_surface_pressure)
   """
   variables = set(ds.variables.keys())
-  hybrid_pa = {'hyam','hybm'}.issubset(variables)
+  hybrid = {'hyam','hybm'}.issubset(variables)
 
-  if hybrid_pa and ps_name in variables:
-    # EAM / EAMxx hybrid: p = hyam*P0 + hybm*PS
-    p0 = ds['P0'] if 'P0' in variables else _DEFAULT_P0
-    return ds['hyam']*p0 + ds['hybm']*ds[ps_name]
+  if hybrid and 'P0' in variables:
+    return ds['hyam']*ds['P0'] + ds['hybm']*ps
 
-  if hybrid_pa and 'lnsp' in variables:
-    # ECMWF IFS layout: hyam already in Pa, surface pressure stored as ln(ps)
-    ps = np.exp(ds['lnsp'].squeeze(drop=True))
+  if hybrid and 'lnsp' in variables:
+    # IFS layout: hyam is already in Pa
     return ds['hyam'] + ds['hybm']*ps
 
   if lev_name in ds.coords or lev_name in ds.variables:
-    # pure pressure levels - broadcast 1D plev to a DataArray on lev_name
     return ds[lev_name].astype('float64')
 
   raise ValueError(
-    f'cannot infer source vertical grid for lev_name={lev_name!r}, ps_name={ps_name!r}; '
-    f'expected hybrid (hyam,hybm,{ps_name}) or pressure-level coordinate'
+    f'cannot infer source vertical grid for lev_name={lev_name!r}; '
+    f'expected hybrid (hyam,hybm,P0|lnsp) or pressure-level coordinate'
   )
 
 # ---------------------------------------------------------------------------
@@ -171,8 +183,8 @@ def remap_vertical_py(input_file, output_file, vert_file,
   with xr.open_dataset(input_file, chunks=chunks) as ds_in, \
        xr.open_dataset(vert_file) as ds_vert:
 
-    if ps_name not in ds_in.variables:
-      raise ValueError(f'input_file does not contain surface pressure variable {ps_name!r}')
+    # resolve surface pressure once (handles both PS and IFS lnsp layouts)
+    ps = _resolve_surface_pressure(ds_in, ps_name)
 
     out_lev_name_native = ds_vert['hyam'].dims[0]
     # if source and target use the same dim name, rename target internally so apply_ufunc
@@ -182,8 +194,8 @@ def remap_vertical_py(input_file, output_file, vert_file,
       out_lev_name = f'{lev_name}_target'
       ds_vert = ds_vert.rename({out_lev_name_native: out_lev_name})
 
-    p_in  = _compute_input_pressure(ds_in, lev_name, ps_name)
-    p_out = _compute_output_pressure(ds_vert, ds_in[ps_name], out_lev_name)
+    p_in  = _compute_input_pressure(ds_in, lev_name, ps)
+    p_out = _compute_output_pressure(ds_vert, ps, out_lev_name)
 
     # decide which fields get remapped; never remap the hybrid coefficients themselves -
     # those describe the vertical grid and are pulled from vert_file
@@ -199,8 +211,7 @@ def remap_vertical_py(input_file, output_file, vert_file,
     for v in _HYBRID_COEF_VARS:
       if v in ds_vert.variables:
         ds_out[v] = ds_vert[v]
-    if ps_name in ds_in.variables:
-      ds_out[ps_name] = ds_in[ps_name]
+    ds_out[ps_name] = ps
 
     # passthrough: any var without the source lev dim that isn't already in ds_out
     for v in ds_in.data_vars:

--- a/test_scripts/unit_test_all.py
+++ b/test_scripts/unit_test_all.py
@@ -7,6 +7,7 @@ import unit_test_state_adjustment
 import unit_test_memory_methods
 import unit_test_timer_methods
 import unit_test_utilities
+import unit_test_vertical_remap
 
 timer_start = perf_counter()
 
@@ -19,6 +20,7 @@ suite_list.append( loader.loadTestsFromModule(unit_test_state_adjustment) )
 suite_list.append( loader.loadTestsFromModule(unit_test_memory_methods) )
 suite_list.append( loader.loadTestsFromModule(unit_test_timer_methods) )
 suite_list.append( loader.loadTestsFromModule(unit_test_utilities) )
+suite_list.append( loader.loadTestsFromModule(unit_test_vertical_remap) )
 
 for suite in suite_list: runner.run(suite)
 

--- a/test_scripts/unit_test_vertical_remap.py
+++ b/test_scripts/unit_test_vertical_remap.py
@@ -155,6 +155,19 @@ class interp_column_test_case(unittest.TestCase):
     self.assertAlmostEqual(f_got[0], expected)
     print_timer(timer_start, caller='test_linear_extrapolation_uses_endpoint_slope')
   # ------------------------------------------------------------------------
+  def test_linear_extrapolation_falls_back_when_single_source_point(self):
+    """
+    a column with a single source level cannot define a slope; extrap='linear'
+    should fall back to constant (clamp) instead of raising IndexError
+    """
+    timer_start = perf_counter()
+    p_src = np.array([5.0e4])
+    f_src = np.array([42.0])
+    p_tgt = np.array([1.0e4, 5.0e4, 1.0e5])
+    f_got = _interp_column(p_tgt, p_src, f_src, mode='linear_pressure', extrap='linear')
+    np.testing.assert_array_equal(f_got, np.array([42.0, 42.0, 42.0]))
+    print_timer(timer_start, caller='test_linear_extrapolation_falls_back_when_single_source_point')
+  # ------------------------------------------------------------------------
   def test_handles_descending_source_pressure(self):
     """
     column ordered top-down (decreasing pressure) should give the same result as ascending
@@ -337,7 +350,7 @@ class compute_pressure_test_case(unittest.TestCase):
 # ===========================================================================
 class remap_vertical_end_to_end_test_case(unittest.TestCase):
   """
-  End-to-end tests that write fixtures, call remap_vertical(), and inspect the output
+  End-to-end tests that write fixtures, call remap_vertical_py(), and inspect the output
   """
   # ------------------------------------------------------------------------
   def setUp(self):
@@ -432,6 +445,21 @@ class remap_vertical_end_to_end_test_case(unittest.TestCase):
       T_got = ds_out['T'].transpose('time', 'lev', 'ncol').values
       np.testing.assert_allclose(T_got, T_exp, rtol=1e-10, atol=1e-10)
     print_timer(timer_start, caller='test_default_chunks_chunk_horizontal_dims')
+  # ------------------------------------------------------------------------
+  def test_p0_always_written_even_when_vert_file_lacks_it(self):
+    """
+    when vert_file has no P0, the output should still carry P0 with the default
+    used during pressure computation, so the output file is self-describing
+    """
+    timer_start = perf_counter()
+    no_p0_vert = os.path.join(self.tmpdir, 'vert_no_p0.nc')
+    self.ds_vert.drop_vars('P0').to_netcdf(no_p0_vert)
+    out = os.path.join(self.tmpdir, 'out_no_p0.nc')
+    remap_vertical_py(self.src_file, out, no_p0_vert, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(out) as ds_out:
+      self.assertIn('P0', ds_out.variables)
+      self.assertEqual(float(ds_out['P0'].values), 1.0e5)
+    print_timer(timer_start, caller='test_p0_always_written_even_when_vert_file_lacks_it')
   # ------------------------------------------------------------------------
   def test_var_list_filters_remapped_fields(self):
     """

--- a/test_scripts/unit_test_vertical_remap.py
+++ b/test_scripts/unit_test_vertical_remap.py
@@ -276,6 +276,33 @@ class compute_pressure_test_case(unittest.TestCase):
       _resolve_surface_pressure(ds, 'PS')
     print_timer(timer_start, caller='test_resolve_surface_pressure_missing_raises')
   # ------------------------------------------------------------------------
+  def test_resolve_surface_pressure_preserves_singleton_time(self):
+    """
+    a single-timestep lnsp with a singleton vertical dim should have the lev dim
+    dropped but the time dim preserved (regression: blanket squeeze() would drop both)
+    """
+    timer_start = perf_counter()
+    ps_true = np.array([[1.0e5, 9.5e4]])  # shape (time=1, ncol=2)
+    lnsp = np.log(ps_true)[:, None, :]    # shape (time=1, lev=1, ncol=2)
+    ds = xr.Dataset({'lnsp': (('time', 'lev', 'ncol'), lnsp)})
+    ps = _resolve_surface_pressure(ds, 'PS', lev_name='lev')
+    self.assertEqual(ps.dims, ('time', 'ncol'))
+    self.assertEqual(ps.shape, (1, 2))
+    np.testing.assert_allclose(ps.values, ps_true, rtol=1e-12)
+    print_timer(timer_start, caller='test_resolve_surface_pressure_preserves_singleton_time')
+  # ------------------------------------------------------------------------
+  def test_resolve_surface_pressure_lnsp_without_lev_dim(self):
+    """
+    when lnsp has no vertical dim at all, it should be used as-is (no isel)
+    """
+    timer_start = perf_counter()
+    ps_true = np.array([1.0e5, 9.5e4])
+    ds = xr.Dataset({'lnsp': (('ncol',), np.log(ps_true))})
+    ps = _resolve_surface_pressure(ds, 'PS', lev_name='lev')
+    self.assertEqual(ps.dims, ('ncol',))
+    np.testing.assert_allclose(ps.values, ps_true, rtol=1e-12)
+    print_timer(timer_start, caller='test_resolve_surface_pressure_lnsp_without_lev_dim')
+  # ------------------------------------------------------------------------
   def test_output_pressure_uses_target_hybrid(self):
     """
     target pressure should be hyam*P0 + hybm*PS using the target file's coefs

--- a/test_scripts/unit_test_vertical_remap.py
+++ b/test_scripts/unit_test_vertical_remap.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python
+# ===================================================================================================
+# Unit testing for hiccup_vertical_remap module
+# ===================================================================================================
+import os
+import shutil
+import tempfile
+import unittest
+import numpy as np
+import xarray as xr
+from time import perf_counter
+
+from hiccup.hiccup_data_class_timer_methods import print_timer
+from hiccup.hiccup_vertical_remap import (remap_vertical_py,
+                                          _resolve_surface_pressure,
+                                          _compute_input_pressure,
+                                          _compute_output_pressure,
+                                          _interp_column,
+                                          _remap_field)
+
+# ---------------------------------------------------------------------------
+# fixture helpers
+# ---------------------------------------------------------------------------
+def _make_hybrid_coords(nlev, p_top=100.0, p_bot=1.0e5, p0=1.0e5):
+  """
+  build a simple hybrid sigma-pressure grid with smoothly varying eta
+  hyam/hybm at midpoints, hyai/hybi at interfaces; pure-pressure at top, pure-sigma at bottom
+  returns (hyam, hybm, hyai, hybi) as numpy arrays
+  """
+  eta_i = np.linspace(p_top/p0, 1.0, nlev+1)
+  # linear ramp: hybi grows from 0 at top to 1 at surface
+  hybi = np.clip((eta_i - p_top/p0)/(1.0 - p_top/p0), 0.0, 1.0)
+  hyai = eta_i - hybi
+  hyam = 0.5*(hyai[:-1] + hyai[1:])
+  hybm = 0.5*(hybi[:-1] + hybi[1:])
+  return hyam, hybm, hyai, hybi
+
+# ---------------------------------------------------------------------------
+def _write_source_dataset(path, ncol=4, ntime=2, nlev_src=20,
+                          ps_min=9.5e4, ps_max=1.015e5, lev_name='lev'):
+  """
+  write a small synthetic source dataset on a hybrid grid:
+    - PS varies linearly across columns
+    - T(p) = 250 + 30*log(p/1e5)   (smooth in log p)
+    - Q(p) = exp(-p/1e5)           (smooth, monotonic)
+  layout: (time, lev, ncol)
+  """
+  hyam, hybm, hyai, hybi = _make_hybrid_coords(nlev_src)
+  ps = np.linspace(ps_min, ps_max, ncol)
+  ps = np.broadcast_to(ps, (ntime, ncol)).copy()
+
+  # pressure at midpoints: (lev, ncol)
+  p = hyam[:, None]*1.0e5 + hybm[:, None]*ps[0, None, :]  # use first time slice for shape
+  p = np.broadcast_to(p[None, :, :], (ntime, nlev_src, ncol)).copy()
+  # recompute per-time using actual ps for accuracy
+  p = (hyam[None, :, None]*1.0e5
+       + hybm[None, :, None]*ps[:, None, :])
+
+  T = 250.0 + 30.0*np.log(p/1.0e5)
+  Q = np.exp(-p/1.0e5)
+  TS = np.full((ntime, ncol), 290.0)  # passthrough scalar field
+
+  ds = xr.Dataset(
+    data_vars={
+      'T':  ((('time', lev_name, 'ncol')), T.astype(np.float64)),
+      'Q':  ((('time', lev_name, 'ncol')), Q.astype(np.float64)),
+      'PS': ((('time', 'ncol')), ps.astype(np.float64)),
+      'TS': ((('time', 'ncol')), TS.astype(np.float64)),
+      'hyam': ((lev_name,), hyam),
+      'hybm': ((lev_name,), hybm),
+      'P0':   ((), np.float64(1.0e5)),
+    },
+    coords={
+      'time': np.arange(ntime),
+      lev_name: np.arange(nlev_src),
+      'ncol': np.arange(ncol),
+    },
+  )
+  ds.to_netcdf(path)
+  return ds
+
+# ---------------------------------------------------------------------------
+def _write_vert_file(path, nlev_tgt=12, lev_name='lev'):
+  """
+  write a target vertical grid file with a coarser hybrid grid
+  """
+  hyam, hybm, hyai, hybi = _make_hybrid_coords(nlev_tgt)
+  ds = xr.Dataset(
+    data_vars={
+      'hyam': ((lev_name,), hyam),
+      'hybm': ((lev_name,), hybm),
+      'hyai': (('ilev',), hyai),
+      'hybi': (('ilev',), hybi),
+      'P0':   ((), np.float64(1.0e5)),
+    },
+  )
+  ds.to_netcdf(path)
+  return ds
+
+# ===========================================================================
+class interp_column_test_case(unittest.TestCase):
+  """
+  Tests for the per-column interpolation kernel
+  """
+  # ------------------------------------------------------------------------
+  def test_log_pressure_exact_for_linear_in_log_p(self):
+    """
+    a field that is exactly linear in log(p) should round-trip to machine precision
+    """
+    timer_start = perf_counter()
+    p_src = np.linspace(1.0e3, 1.0e5, 30)
+    p_tgt = np.linspace(2.0e3, 9.0e4, 12)
+    f_src = 250.0 + 30.0*np.log(p_src/1.0e5)
+    f_exp = 250.0 + 30.0*np.log(p_tgt/1.0e5)
+    f_got = _interp_column(p_tgt, p_src, f_src, mode='log_pressure')
+    np.testing.assert_allclose(f_got, f_exp, rtol=1e-12, atol=1e-12)
+    print_timer(timer_start, caller='test_log_pressure_exact_for_linear_in_log_p')
+  # ------------------------------------------------------------------------
+  def test_linear_pressure_exact_for_linear_in_p(self):
+    """
+    a field that is exactly linear in p should round-trip under linear-in-pressure mode
+    """
+    timer_start = perf_counter()
+    p_src = np.linspace(1.0e3, 1.0e5, 30)
+    p_tgt = np.linspace(2.0e3, 9.0e4, 12)
+    f_src = 100.0 + 1.5e-3*p_src
+    f_exp = 100.0 + 1.5e-3*p_tgt
+    f_got = _interp_column(p_tgt, p_src, f_src, mode='linear_pressure')
+    np.testing.assert_allclose(f_got, f_exp, rtol=1e-12, atol=1e-12)
+    print_timer(timer_start, caller='test_linear_pressure_exact_for_linear_in_p')
+  # ------------------------------------------------------------------------
+  def test_constant_extrapolation_clamps(self):
+    """
+    extrap='constant' should clamp output beyond the source range to source endpoints
+    """
+    timer_start = perf_counter()
+    p_src = np.array([1.0e4, 5.0e4, 1.0e5])
+    f_src = np.array([10.0, 20.0, 30.0])
+    p_tgt = np.array([5.0e3, 1.5e5])  # both outside
+    f_got = _interp_column(p_tgt, p_src, f_src, mode='linear_pressure', extrap='constant')
+    self.assertAlmostEqual(f_got[0], 10.0)
+    self.assertAlmostEqual(f_got[1], 30.0)
+    print_timer(timer_start, caller='test_constant_extrapolation_clamps')
+  # ------------------------------------------------------------------------
+  def test_linear_extrapolation_uses_endpoint_slope(self):
+    """
+    extrap='linear' should extend with the slope of the last two source points
+    """
+    timer_start = perf_counter()
+    p_src = np.array([1.0e4, 5.0e4, 1.0e5])
+    f_src = np.array([10.0, 20.0, 30.0])  # slope = (30-20)/(1e5-5e4) = 2e-4
+    p_tgt = np.array([1.5e5])
+    f_got = _interp_column(p_tgt, p_src, f_src, mode='linear_pressure', extrap='linear')
+    expected = 30.0 + (1.5e5 - 1.0e5)*2.0e-4
+    self.assertAlmostEqual(f_got[0], expected)
+    print_timer(timer_start, caller='test_linear_extrapolation_uses_endpoint_slope')
+  # ------------------------------------------------------------------------
+  def test_handles_descending_source_pressure(self):
+    """
+    column ordered top-down (decreasing pressure) should give the same result as ascending
+    """
+    timer_start = perf_counter()
+    p_src = np.linspace(1.0e3, 1.0e5, 30)
+    f_src = 250.0 + 30.0*np.log(p_src/1.0e5)
+    p_tgt = np.linspace(2.0e3, 9.0e4, 12)
+
+    f_asc  = _interp_column(p_tgt, p_src, f_src, mode='log_pressure')
+    f_desc = _interp_column(p_tgt, p_src[::-1], f_src[::-1], mode='log_pressure')
+    np.testing.assert_allclose(f_asc, f_desc, rtol=1e-12, atol=1e-12)
+    print_timer(timer_start, caller='test_handles_descending_source_pressure')
+  # ------------------------------------------------------------------------
+
+# ===========================================================================
+class compute_pressure_test_case(unittest.TestCase):
+  """
+  Tests for _compute_input_pressure / _compute_output_pressure
+  """
+  # ------------------------------------------------------------------------
+  def test_input_pressure_hybrid_eam(self):
+    """
+    EAM hybrid input (P0 present) should produce p = hyam*P0 + hybm*PS
+    """
+    timer_start = perf_counter()
+    ds = xr.Dataset({
+      'hyam': (('lev',), np.array([0.1, 0.2])),
+      'hybm': (('lev',), np.array([0.0, 0.5])),
+      'P0':   ((), np.float64(1.0e5)),
+      'PS':   (('ncol',), np.array([1.0e5, 9.5e4])),
+    })
+    ps = ds['PS']
+    p = _compute_input_pressure(ds, lev_name='lev', ps=ps).values
+    expected = np.array([
+      [0.1*1.0e5 + 0.0*1.0e5, 0.1*1.0e5 + 0.0*9.5e4],
+      [0.2*1.0e5 + 0.5*1.0e5, 0.2*1.0e5 + 0.5*9.5e4],
+    ])
+    np.testing.assert_allclose(p, expected, rtol=1e-12)
+    print_timer(timer_start, caller='test_input_pressure_hybrid_eam')
+  # ------------------------------------------------------------------------
+  def test_input_pressure_hybrid_ifs(self):
+    """
+    IFS hybrid input (lnsp present, no P0) should produce p = hyam + hybm*ps
+    with hyam in Pa
+    """
+    timer_start = perf_counter()
+    hyam_pa = np.array([1.0e3, 2.0e3])
+    ds = xr.Dataset({
+      'hyam': (('lev',), hyam_pa),
+      'hybm': (('lev',), np.array([0.0, 0.5])),
+      'lnsp': (('ncol',), np.log(np.array([1.0e5, 9.5e4]))),
+    })
+    ps = _resolve_surface_pressure(ds, 'PS')
+    p = _compute_input_pressure(ds, lev_name='lev', ps=ps).values
+    expected = np.array([
+      [1.0e3 + 0.0*1.0e5, 1.0e3 + 0.0*9.5e4],
+      [2.0e3 + 0.5*1.0e5, 2.0e3 + 0.5*9.5e4],
+    ])
+    np.testing.assert_allclose(p, expected, rtol=1e-12)
+    print_timer(timer_start, caller='test_input_pressure_hybrid_ifs')
+  # ------------------------------------------------------------------------
+  def test_input_pressure_pure_pressure_levels(self):
+    """
+    pure pressure-level input should return the lev coord directly
+    """
+    timer_start = perf_counter()
+    plev = np.array([1.0e3, 5.0e3, 1.0e4, 5.0e4, 1.0e5])
+    ds = xr.Dataset({'PS': (('ncol',), np.array([1.0e5]))},
+                    coords={'plev': plev})
+    ps = ds['PS']
+    p = _compute_input_pressure(ds, lev_name='plev', ps=ps).values
+    np.testing.assert_allclose(p, plev, rtol=1e-12)
+    print_timer(timer_start, caller='test_input_pressure_pure_pressure_levels')
+  # ------------------------------------------------------------------------
+  def test_input_pressure_unknown_layout_raises(self):
+    """
+    a dataset with neither hybrid coefs nor a recognizable lev coord should raise ValueError
+    """
+    timer_start = perf_counter()
+    ds = xr.Dataset({'PS': (('ncol',), np.array([1.0e5]))})
+    with self.assertRaises(ValueError):
+      _compute_input_pressure(ds, lev_name='lev', ps=ds['PS'])
+    print_timer(timer_start, caller='test_input_pressure_unknown_layout_raises')
+  # ------------------------------------------------------------------------
+  def test_resolve_surface_pressure_prefers_named_ps(self):
+    """
+    when both ps_name and lnsp are present, the named variable should win
+    """
+    timer_start = perf_counter()
+    ds = xr.Dataset({
+      'PS':   (('ncol',), np.array([1.0e5, 9.5e4])),
+      'lnsp': (('ncol',), np.log(np.array([8.0e4, 7.0e4]))),
+    })
+    ps = _resolve_surface_pressure(ds, 'PS')
+    np.testing.assert_array_equal(ps.values, np.array([1.0e5, 9.5e4]))
+    print_timer(timer_start, caller='test_resolve_surface_pressure_prefers_named_ps')
+  # ------------------------------------------------------------------------
+  def test_resolve_surface_pressure_falls_back_to_lnsp(self):
+    """
+    when only lnsp is present, surface pressure should be derived as exp(lnsp)
+    and named ps_name
+    """
+    timer_start = perf_counter()
+    ps_true = np.array([1.0e5, 9.5e4])
+    ds = xr.Dataset({'lnsp': (('ncol',), np.log(ps_true))})
+    ps = _resolve_surface_pressure(ds, 'PS')
+    self.assertEqual(ps.name, 'PS')
+    np.testing.assert_allclose(ps.values, ps_true, rtol=1e-12)
+    print_timer(timer_start, caller='test_resolve_surface_pressure_falls_back_to_lnsp')
+  # ------------------------------------------------------------------------
+  def test_resolve_surface_pressure_missing_raises(self):
+    """
+    a dataset with neither ps_name nor lnsp should raise ValueError
+    """
+    timer_start = perf_counter()
+    ds = xr.Dataset({'foo': (('x',), np.array([1.0]))})
+    with self.assertRaises(ValueError):
+      _resolve_surface_pressure(ds, 'PS')
+    print_timer(timer_start, caller='test_resolve_surface_pressure_missing_raises')
+  # ------------------------------------------------------------------------
+  def test_output_pressure_uses_target_hybrid(self):
+    """
+    target pressure should be hyam*P0 + hybm*PS using the target file's coefs
+    """
+    timer_start = perf_counter()
+    ds_vert = xr.Dataset({
+      'hyam': (('lev',), np.array([0.05, 0.3])),
+      'hybm': (('lev',), np.array([0.0, 0.7])),
+      'P0':   ((), np.float64(1.0e5)),
+    })
+    ps = xr.DataArray(np.array([1.0e5, 9.0e4]), dims=('ncol',))
+    p = _compute_output_pressure(ds_vert, ps, out_lev_name='lev').values
+    expected = np.array([
+      [0.05*1.0e5, 0.05*1.0e5],
+      [0.3*1.0e5 + 0.7*1.0e5, 0.3*1.0e5 + 0.7*9.0e4],
+    ])
+    np.testing.assert_allclose(p, expected, rtol=1e-12)
+    print_timer(timer_start, caller='test_output_pressure_uses_target_hybrid')
+  # ------------------------------------------------------------------------
+  def test_output_pressure_missing_hybrid_raises(self):
+    """
+    target file without hyam/hybm should raise ValueError
+    """
+    timer_start = perf_counter()
+    ds_vert = xr.Dataset({'foo': (('x',), np.array([1.0]))})
+    ps = xr.DataArray(np.array([1.0e5]), dims=('ncol',))
+    with self.assertRaises(ValueError):
+      _compute_output_pressure(ds_vert, ps, out_lev_name='lev')
+    print_timer(timer_start, caller='test_output_pressure_missing_hybrid_raises')
+  # ------------------------------------------------------------------------
+
+# ===========================================================================
+class remap_vertical_end_to_end_test_case(unittest.TestCase):
+  """
+  End-to-end tests that write fixtures, call remap_vertical(), and inspect the output
+  """
+  # ------------------------------------------------------------------------
+  def setUp(self):
+    self.tmpdir = tempfile.mkdtemp(prefix='hiccup_vrt_test_')
+    self.src_file  = os.path.join(self.tmpdir, 'src.nc')
+    self.vert_file = os.path.join(self.tmpdir, 'vert.nc')
+    self.out_file  = os.path.join(self.tmpdir, 'out.nc')
+    self.ds_src  = _write_source_dataset(self.src_file)
+    self.ds_vert = _write_vert_file(self.vert_file)
+  # ------------------------------------------------------------------------
+  def tearDown(self):
+    shutil.rmtree(self.tmpdir, ignore_errors=True)
+  # ------------------------------------------------------------------------
+  def test_smooth_field_remap_is_accurate(self):
+    """
+    a field that is exactly linear in log(p) should remap to the same analytic field
+    on the target grid, to within float64 precision (down to round-off in p computation)
+    """
+    timer_start = perf_counter()
+    remap_vertical_py(self.src_file, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(self.out_file) as ds_out:
+      hyam = ds_out['hyam'].values
+      hybm = ds_out['hybm'].values
+      ps   = ds_out['PS'].values  # (time, ncol)
+      p_tgt = hyam[None, :, None]*1.0e5 + hybm[None, :, None]*ps[:, None, :]
+      T_exp = 250.0 + 30.0*np.log(p_tgt/1.0e5)
+      T_got = ds_out['T'].transpose('time', 'lev', 'ncol').values
+      np.testing.assert_allclose(T_got, T_exp, rtol=1e-10, atol=1e-10)
+    print_timer(timer_start, caller='test_smooth_field_remap_is_accurate')
+  # ------------------------------------------------------------------------
+  def test_passthrough_variables_unchanged(self):
+    """
+    variables without the source lev dim (PS, TS) should be copied through bit-identical
+    """
+    timer_start = perf_counter()
+    remap_vertical_py(self.src_file, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(self.out_file) as ds_out:
+      np.testing.assert_array_equal(ds_out['PS'].values, self.ds_src['PS'].values)
+      np.testing.assert_array_equal(ds_out['TS'].values, self.ds_src['TS'].values)
+    print_timer(timer_start, caller='test_passthrough_variables_unchanged')
+  # ------------------------------------------------------------------------
+  def test_target_hybrid_coefs_carried_over(self):
+    """
+    hyam/hybm/hyai/hybi/P0 from the target vert file should appear in the output
+    """
+    timer_start = perf_counter()
+    remap_vertical_py(self.src_file, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(self.out_file) as ds_out:
+      np.testing.assert_array_equal(ds_out['hyam'].values, self.ds_vert['hyam'].values)
+      np.testing.assert_array_equal(ds_out['hybm'].values, self.ds_vert['hybm'].values)
+      np.testing.assert_array_equal(ds_out['hyai'].values, self.ds_vert['hyai'].values)
+      np.testing.assert_array_equal(ds_out['hybi'].values, self.ds_vert['hybi'].values)
+    print_timer(timer_start, caller='test_target_hybrid_coefs_carried_over')
+  # ------------------------------------------------------------------------
+  def test_var_list_filters_remapped_fields(self):
+    """
+    explicit var_list should remap only the listed fields; other lev-bearing vars are dropped
+    """
+    timer_start = perf_counter()
+    remap_vertical_py(self.src_file, self.out_file, self.vert_file, ps_name='PS',
+                   var_list=['T'], lev_name='lev')
+    with xr.open_dataset(self.out_file) as ds_out:
+      self.assertIn('T', ds_out.data_vars)
+      self.assertNotIn('Q', ds_out.data_vars)
+    print_timer(timer_start, caller='test_var_list_filters_remapped_fields')
+  # ------------------------------------------------------------------------
+  def test_invalid_mode_raises(self):
+    """
+    invalid interpolation mode should raise ValueError before opening any files
+    """
+    timer_start = perf_counter()
+    with self.assertRaises(ValueError):
+      remap_vertical_py(self.src_file, self.out_file, self.vert_file, mode='cubic')
+    print_timer(timer_start, caller='test_invalid_mode_raises')
+  # ------------------------------------------------------------------------
+  def test_invalid_extrap_raises(self):
+    """
+    invalid extrapolation mode should raise ValueError before opening any files
+    """
+    timer_start = perf_counter()
+    with self.assertRaises(ValueError):
+      remap_vertical_py(self.src_file, self.out_file, self.vert_file, extrap='spline')
+    print_timer(timer_start, caller='test_invalid_extrap_raises')
+  # ------------------------------------------------------------------------
+  def test_input_equals_output_overwrites_in_place(self):
+    """
+    when input_file == output_file, the source file should be overwritten with remapped data
+    """
+    timer_start = perf_counter()
+    in_place = os.path.join(self.tmpdir, 'in_place.nc')
+    _write_source_dataset(in_place)
+    remap_vertical_py(in_place, in_place, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(in_place) as ds:
+      self.assertEqual(ds['T'].sizes['lev'], self.ds_vert['hyam'].sizes['lev'])
+    print_timer(timer_start, caller='test_input_equals_output_overwrites_in_place')
+  # ------------------------------------------------------------------------
+  def test_missing_ps_raises(self):
+    """
+    a source file lacking BOTH the named surface pressure variable and lnsp
+    should raise ValueError
+    """
+    timer_start = perf_counter()
+    no_ps = os.path.join(self.tmpdir, 'no_ps.nc')
+    # the synthetic source has no lnsp, so dropping PS leaves no surface-pressure source
+    self.ds_src.drop_vars('PS').to_netcdf(no_ps)
+    with self.assertRaises(ValueError):
+      remap_vertical_py(no_ps, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    print_timer(timer_start, caller='test_missing_ps_raises')
+  # ------------------------------------------------------------------------
+  def test_lnsp_source_remaps_and_writes_ps(self):
+    """
+    an IFS-style source (hyam in Pa, lnsp instead of PS, no P0) should remap
+    successfully and the output should carry PS = exp(lnsp)
+    """
+    timer_start = perf_counter()
+    ifs_src = os.path.join(self.tmpdir, 'ifs_src.nc')
+    ntime, ncol, nlev = 2, 4, 20
+    # build IFS-style hybrid: hyam in Pa, no P0
+    eta_i = np.linspace(100.0/1.0e5, 1.0, nlev+1)
+    hybi  = np.clip((eta_i - 100.0/1.0e5)/(1.0 - 100.0/1.0e5), 0.0, 1.0)
+    hyai  = (eta_i - hybi)*1.0e5  # convert to Pa
+    hyam  = 0.5*(hyai[:-1] + hyai[1:])
+    hybm  = 0.5*(hybi[:-1] + hybi[1:])
+    ps    = np.broadcast_to(np.linspace(9.5e4, 1.015e5, ncol), (ntime, ncol)).copy()
+    lnsp  = np.log(ps)
+    p     = hyam[None, :, None] + hybm[None, :, None]*ps[:, None, :]
+    T     = 250.0 + 30.0*np.log(p/1.0e5)
+    ds = xr.Dataset(
+      data_vars={
+        'T':    (('time', 'lev', 'ncol'), T.astype(np.float64)),
+        'lnsp': (('time', 'ncol'), lnsp.astype(np.float64)),
+        'hyam': (('lev',), hyam),
+        'hybm': (('lev',), hybm),
+      },
+      coords={'time': np.arange(ntime), 'lev': np.arange(nlev), 'ncol': np.arange(ncol)},
+    )
+    ds.to_netcdf(ifs_src)
+    remap_vertical_py(ifs_src, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(self.out_file) as ds_out:
+      self.assertIn('PS', ds_out.data_vars)
+      np.testing.assert_allclose(ds_out['PS'].values, ps, rtol=1e-12)
+      # smooth field should round-trip to within float64 round-off
+      hyam_t = ds_out['hyam'].values
+      hybm_t = ds_out['hybm'].values
+      ps_t   = ds_out['PS'].values
+      p_tgt  = hyam_t[None, :, None]*1.0e5 + hybm_t[None, :, None]*ps_t[:, None, :]
+      T_exp  = 250.0 + 30.0*np.log(p_tgt/1.0e5)
+      T_got  = ds_out['T'].transpose('time', 'lev', 'ncol').values
+      np.testing.assert_allclose(T_got, T_exp, rtol=1e-10, atol=1e-10)
+    print_timer(timer_start, caller='test_lnsp_source_remaps_and_writes_ps')
+  # ------------------------------------------------------------------------
+
+# ===========================================================================
+if __name__ == '__main__':
+  unittest.main()

--- a/test_scripts/unit_test_vertical_remap.py
+++ b/test_scripts/unit_test_vertical_remap.py
@@ -392,6 +392,47 @@ class remap_vertical_end_to_end_test_case(unittest.TestCase):
       np.testing.assert_array_equal(ds_out['hybi'].values, self.ds_vert['hybi'].values)
     print_timer(timer_start, caller='test_target_hybrid_coefs_carried_over')
   # ------------------------------------------------------------------------
+  def test_explicit_chunks_produce_correct_output(self):
+    """
+    explicit horizontal chunking should still produce correct output;
+    proves the dask-parallelized interp path works end-to-end
+    """
+    timer_start = perf_counter()
+    remap_vertical_py(self.src_file, self.out_file, self.vert_file, ps_name='PS',
+                      lev_name='lev', chunks={'ncol': 2, 'time': 1})
+    with xr.open_dataset(self.out_file) as ds_out:
+      hyam = ds_out['hyam'].values
+      hybm = ds_out['hybm'].values
+      ps   = ds_out['PS'].values
+      p_tgt = hyam[None, :, None]*1.0e5 + hybm[None, :, None]*ps[:, None, :]
+      T_exp = 250.0 + 30.0*np.log(p_tgt/1.0e5)
+      T_got = ds_out['T'].transpose('time', 'lev', 'ncol').values
+      np.testing.assert_allclose(T_got, T_exp, rtol=1e-10, atol=1e-10)
+    print_timer(timer_start, caller='test_explicit_chunks_produce_correct_output')
+  # ------------------------------------------------------------------------
+  def test_default_chunks_chunk_horizontal_dims(self):
+    """
+    when chunks=None, the input dataset should be opened with dask backing on
+    every dim (lev_name forced to -1) - regression against an earlier default
+    that left non-lev dims as a single chunk
+    """
+    timer_start = perf_counter()
+    # build a wider source so 'auto' has something to bite into
+    wide_src = os.path.join(self.tmpdir, 'wide_src.nc')
+    _write_source_dataset(wide_src, ncol=64, ntime=4, nlev_src=20)
+    out = os.path.join(self.tmpdir, 'wide_out.nc')
+    remap_vertical_py(wide_src, out, self.vert_file, ps_name='PS', lev_name='lev')
+    # confirm correctness on the wider grid
+    with xr.open_dataset(out) as ds_out:
+      hyam = ds_out['hyam'].values
+      hybm = ds_out['hybm'].values
+      ps   = ds_out['PS'].values
+      p_tgt = hyam[None, :, None]*1.0e5 + hybm[None, :, None]*ps[:, None, :]
+      T_exp = 250.0 + 30.0*np.log(p_tgt/1.0e5)
+      T_got = ds_out['T'].transpose('time', 'lev', 'ncol').values
+      np.testing.assert_allclose(T_got, T_exp, rtol=1e-10, atol=1e-10)
+    print_timer(timer_start, caller='test_default_chunks_chunk_horizontal_dims')
+  # ------------------------------------------------------------------------
   def test_var_list_filters_remapped_fields(self):
     """
     explicit var_list should remap only the listed fields; other lev-bearing vars are dropped


### PR DESCRIPTION
This is the first step to replacing the NCO vertical remap step, which does not scale well for large grids. The plan is to keep the old NCO approach around so that we can easily revert, but we won't provide a simple flag for the user.