### PR TITLE
EAM bug fix and other updates

### DIFF
--- a/hiccup/hiccup.py
+++ b/hiccup/hiccup.py
@@ -11,6 +11,10 @@ from hiccup.hiccup_utilities import tcolor
 
 default_target_model = 'EAM'
 
+# canonical target model names - these exact spellings are what the rest of HICCUP
+# compares against, so verify_target_model() normalizes user input back to them
+valid_target_model_list = ['EAM','EAMXX','EAMXX-nudging']
+
 # default output paths
 default_output_dir  = './data'
 default_grid_dir    = './files_grid'
@@ -86,14 +90,17 @@ def get_default_topo_file_name(grid,topo_file_root=None):
 # ------------------------------------------------------------------------------
 def verify_target_model(target_model):
     """
-    Normalize and validate target_model name (only EAM or EAMXX)
+    Normalize and validate target_model name
     """
     if not isinstance(target_model, str):
         raise ValueError(f'target_model must be a string => {target_model!r}')
-    normalized = target_model.upper()
-    if normalized not in ['EAM', 'EAMXX']:
-        raise ValueError(f'target_model is not valid => {target_model}')
-    return normalized
+    # Match case-insensitively but return the canonical spelling, since the rest of
+    # HICCUP compares against these exact strings - note that "EAMXX-nudging" is mixed
+    # case, so a blanket .upper() would silently disable every branch that checks for it
+    for valid_target_model in valid_target_model_list:
+        if target_model.upper()==valid_target_model.upper(): return valid_target_model
+    raise ValueError(f'target_model is not valid => {target_model}'
+                     f'\n  valid options => {valid_target_model_list}')
 # ------------------------------------------------------------------------------
 # Method for returning class object
 # ------------------------------------------------------------------------------

--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -1498,10 +1498,48 @@ class hiccup_data(object):
         if print_memory_usage: self.print_mem_usage(msg=f'after {sys._getframe(0).f_code.co_name}')
         return
     # --------------------------------------------------------------------------
+    def check_dimension_order(self,ds,expected_dim_list,file_name=None,verbose=None):
+        """
+        Verify that variables use the expected relative dimension order.
+        E3SM reads initial condition files positionally and does not validate the
+        layout, so a transposed field produces garbage instead of an error - it
+        typically blows up in the dycore on the very first step. Only the relative
+        order of the recognized dims is checked, so extra dims (dim2, nv, nbnd)
+        may appear anywhere without tripping the check.
+        """
+        if verbose is None: verbose = self.verbose
+
+        # map the generic horizontal dim name onto whatever this dataset actually uses
+        expected_dim_list = list(expected_dim_list)
+        if 'ncol' in expected_dim_list \
+        and 'ncol' not in ds.dims and 'ncol_d' in ds.dims:
+            expected_dim_list[expected_dim_list.index('ncol')] = 'ncol_d'
+
+        bad_var_list = []
+        for var in ds.data_vars:
+            var_dims = [d for d in ds[var].dims if d in expected_dim_list]
+            if var_dims != sorted(var_dims,key=expected_dim_list.index):
+                bad_var_list.append(f'      {var}{ds[var].dims}')
+
+        if bad_var_list:
+            msg  = f'{tcolor.RED}Unexpected dimension order'
+            if file_name is not None: msg += f' in {file_name}'
+            msg += '\n'
+            msg += f'    expected order: {tuple(expected_dim_list)}\n'
+            msg += '    offending variables:\n'
+            msg += '\n'.join(bad_var_list)
+            msg += f'{tcolor.ENDC}'
+            raise ValueError(msg)
+
+        if verbose:
+            print(f'{self.verbose_indent}  dimension order OK: {tuple(expected_dim_list)}')
+        return
+    # --------------------------------------------------------------------------
     def combine_files(self,file_dict,output_file_name,delete_files=False,
                       method='xarray',use_single_precision=None,
                       permute_dimensions=None,permute_dim_list=None,
-                      combine_uv=None,remove_ilev=None,verbose=None):
+                      combine_uv=None,
+                      check_dim_order=True,expected_dim_list=None,verbose=None):
         """
         Combine files in file_dict into single output file
         """
@@ -1521,22 +1559,22 @@ class hiccup_data(object):
             u_name,v_name,uv_name = 'U','V','UV'
             if use_single_precision is None: use_single_precision = False
             if permute_dimensions is None: permute_dimensions = False
+            if expected_dim_list is None: expected_dim_list = ['time','lev','ncol']
             if combine_uv is None: combine_uv = False
-            if remove_ilev is None: remove_ilev = False
         if self.target_model=='EAMXX':
             u_name,v_name,uv_name = 'horiz_winds_u','horiz_winds_v','horiz_winds'
             if use_single_precision is None: use_single_precision = True
             if permute_dimensions is None: permute_dimensions = True
             if permute_dim_list is None:permute_dim_list = ['time','ncol','lev']
+            if expected_dim_list is None: expected_dim_list = permute_dim_list
             if combine_uv is None: combine_uv = True
-            if remove_ilev is None: remove_ilev = False
         if self.target_model=='EAMXX-nudging':
             u_name,v_name,uv_name = 'horiz_winds_u','horiz_winds_v','horiz_winds'
             if use_single_precision is None: use_single_precision = True
             if permute_dimensions is None: permute_dimensions = True
             if permute_dim_list is None: permute_dim_list = ['time','ncol','lev']
+            if expected_dim_list is None: expected_dim_list = permute_dim_list
             if combine_uv is None: combine_uv = False
-            if remove_ilev is None: remove_ilev = True
 
         print()
         print(f'permute_dimensions: {permute_dimensions}')
@@ -1600,6 +1638,12 @@ class hiccup_data(object):
                 # if 'ni' not in file_dict.keys() and 'qv' in file_dict.keys():
                 #     ds_out['ni'] = ds_out['qv'].copy(deep=True)*0
                 #     ds_out['ni'].attrs['long_name'] = 'Grid box averaged cloud ice number'
+            # validate the layout before writing - a transposed IC is read without
+            # complaint by E3SM and only shows up as a dycore blow-up on step 1
+            if check_dim_order:
+                self.check_dimension_order(ds_out,expected_dim_list,
+                                           file_name=output_file_name,verbose=verbose)
+
             ds_out.to_netcdf(output_file_name)
             ds_out.close()
 

--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -1511,13 +1511,16 @@ class hiccup_data(object):
 
         # map the generic horizontal dim name onto whatever this dataset actually uses
         expected_dim_list = list(expected_dim_list)
-        if 'ncol' in expected_dim_list \
-        and 'ncol' not in ds.dims and 'ncol_d' in ds.dims:
-            expected_dim_list[expected_dim_list.index('ncol')] = 'ncol_d'
+        dim_alias = {}
+        if 'ncol' in expected_dim_list and 'ncol_d' in ds.dims:
+            if 'ncol' not in ds.dims:
+                expected_dim_list[expected_dim_list.index('ncol')] = 'ncol_d'
+            else:
+                dim_alias['ncol_d'] = 'ncol'
 
         bad_var_list = []
         for var in ds.data_vars:
-            var_dims = [d for d in ds[var].dims if d in expected_dim_list]
+            var_dims = [dim_alias.get(d, d) for d in ds[var].dims if dim_alias.get(d, d) in expected_dim_list]
             if var_dims != sorted(var_dims,key=expected_dim_list.index):
                 bad_var_list.append(f'      {var}{ds[var].dims}')
 

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -147,6 +147,15 @@ def _remap_field(field, p_in, p_out, in_lev_name, out_lev_name, mode, extrap):
     output_dtypes=[out_dtype],
   )
   result.attrs = dict(field.attrs)
+
+  # apply_ufunc always moves core dims to the last axis, so a (time,lev,ncol) field
+  # would come back as (time,ncol,lev). The NCO path this replaced was order-preserving,
+  # and EAM expects the vertical dim in its original slot, so restore the source layout.
+  # The trailing Ellipsis is defensive - it parks any dim not present in the source
+  # field (from broadcasting against p_in/p_out) at the end instead of raising.
+  dim_order = [out_lev_name if d==in_lev_name else d for d in field.dims]
+  result = result.transpose(*dim_order, ...)
+
   return result
 
 # ---------------------------------------------------------------------------

--- a/test_scripts/unit_test_data_class.py
+++ b/test_scripts/unit_test_data_class.py
@@ -471,6 +471,110 @@ class hiccup_data_class_test_case(unittest.TestCase):
     finally:
       os.remove(tmp.name)
     print_timer(timer_start, caller='test_check_input_times_and_get_time_index')
+  # ----------------------------------------------------------------------------
+  def _make_dim_order_ds(self, dim_order=('time','lev','ncol')):
+    """helper - tiny dataset whose 3D fields use the requested dim order"""
+    sizes = {'time':1,'lev':4,'ncol':6}
+    shape = tuple(sizes[d] for d in dim_order)
+    return xr.Dataset({
+      'T':  xr.DataArray(np.zeros(shape), dims=list(dim_order)),
+      'PS': xr.DataArray(np.zeros((1,6)), dims=['time','ncol']),
+    })
+  # ----------------------------------------------------------------------------
+  def test_check_dimension_order(self):
+    """
+    check_dimension_order should accept the expected layout and reject a transposed one
+    """
+    timer_start = perf_counter()
+    obj = self.hiccup_data_ERA5
+
+    # happy path - EAM layout
+    ds_good = self._make_dim_order_ds(('time','lev','ncol'))
+    obj.check_dimension_order(ds_good,['time','lev','ncol'],verbose=False)
+
+    # error path - transposed field is the regression this check exists to catch
+    ds_bad = self._make_dim_order_ds(('time','ncol','lev'))
+    with self.assertRaises(ValueError) as ctx:
+      obj.check_dimension_order(ds_bad,['time','lev','ncol'],verbose=False)
+    self.assertIn('T',str(ctx.exception))
+
+    # the same dataset is valid under the EAMxx expected order
+    obj.check_dimension_order(ds_bad,['time','ncol','lev'],verbose=False)
+    print_timer(timer_start, caller='test_check_dimension_order')
+  # ----------------------------------------------------------------------------
+  def test_check_dimension_order_ignores_extra_dims(self):
+    """
+    only the relative order of recognized dims matters - extra dims (dim2, nv, nbnd)
+    may appear anywhere, so EAMxx horiz_winds and grid metadata must not trip the check
+    """
+    timer_start = perf_counter()
+    obj = self.hiccup_data_ERA5
+    ds = xr.Dataset({
+      'horiz_winds':   xr.DataArray(np.zeros((1,6,2,4)), dims=['time','ncol','dim2','lev']),
+      'lat_vertices':  xr.DataArray(np.zeros((6,4)),     dims=['ncol','nv']),
+      'time_bnds':     xr.DataArray(np.zeros((1,2)),     dims=['time','nbnd']),
+      'hyai':          xr.DataArray(np.zeros(5),         dims=['ilev']),
+    })
+    obj.check_dimension_order(ds,['time','ncol','lev'],verbose=False)
+    print_timer(timer_start, caller='test_check_dimension_order_ignores_extra_dims')
+  # ----------------------------------------------------------------------------
+  def test_check_dimension_order_handles_ncol_d(self):
+    """
+    a dataset using ncol_d should be checked against ncol_d in the expected slot
+    """
+    timer_start = perf_counter()
+    obj = self.hiccup_data_ERA5
+    ds_good = xr.Dataset({'T': xr.DataArray(np.zeros((1,4,6)), dims=['time','lev','ncol_d'])})
+    obj.check_dimension_order(ds_good,['time','lev','ncol'],verbose=False)
+    ds_bad = xr.Dataset({'T': xr.DataArray(np.zeros((1,6,4)), dims=['time','ncol_d','lev'])})
+    self.assertRaises(ValueError, obj.check_dimension_order, ds_bad, ['time','lev','ncol'], None, False)
+    print_timer(timer_start, caller='test_check_dimension_order_handles_ncol_d')
+  # ----------------------------------------------------------------------------
+  def test_verify_target_model_valid_names(self):
+    """
+    all supported target models should be accepted and returned in canonical spelling
+    """
+    timer_start = perf_counter()
+    for name in ['EAM','EAMXX','EAMXX-nudging']:
+      self.assertEqual(hiccup.verify_target_model(name), name)
+    print_timer(timer_start, caller='test_verify_target_model_valid_names')
+  # ----------------------------------------------------------------------------
+  def test_verify_target_model_is_case_insensitive(self):
+    """
+    input is matched case-insensitively but normalized back to the canonical spelling,
+    since the rest of HICCUP compares against these exact strings - "EAMXX-nudging" is
+    mixed case, so returning an upper-cased name would silently disable its branches
+    """
+    timer_start = perf_counter()
+    self.assertEqual(hiccup.verify_target_model('eam'), 'EAM')
+    self.assertEqual(hiccup.verify_target_model('eamxx'), 'EAMXX')
+    for name in ['eamxx-nudging','EAMXX-NUDGING','EAMxx-Nudging']:
+      self.assertEqual(hiccup.verify_target_model(name), 'EAMXX-nudging')
+    print_timer(timer_start, caller='test_verify_target_model_is_case_insensitive')
+  # ----------------------------------------------------------------------------
+  def test_verify_target_model_invalid(self):
+    """
+    unrecognized names and non-string input should raise ValueError
+    """
+    timer_start = perf_counter()
+    for bad in ['EAMXX-foo','CAM','',None,5,['EAM']]:
+      self.assertRaises(ValueError, hiccup.verify_target_model, bad)
+    print_timer(timer_start, caller='test_verify_target_model_invalid')
+  # ----------------------------------------------------------------------------
+  def test_create_hiccup_data_accepts_eamxx_nudging(self):
+    """
+    EAMXX-nudging must survive create_hiccup_data() - it is a supported target model
+    with dedicated branches in combine_files() and remap_vertical_multifile()
+    """
+    timer_start = perf_counter()
+    obj = hiccup.create_hiccup_data( src_data_name='ERA5',
+                                     target_model='EAMXX-nudging',
+                                     dst_horz_grid='ne30np4',
+                                     dst_vert_grid='L128',
+                                     input_file_list=[f'{TEST_DATA}/HICCUP_TEST.ERA5.atm.low-res.nc',
+                                                      f'{TEST_DATA}/HICCUP_TEST.ERA5.sfc.low-res.nc'])
+    self.assertEqual(obj.target_model, 'EAMXX-nudging')
+    print_timer(timer_start, caller='test_create_hiccup_data_accepts_eamxx_nudging')
 #===============================================================================
 if __name__ == '__main__':
     unittest.main()

--- a/test_scripts/unit_test_vertical_remap.py
+++ b/test_scripts/unit_test_vertical_remap.py
@@ -381,6 +381,39 @@ class remap_vertical_end_to_end_test_case(unittest.TestCase):
       np.testing.assert_allclose(T_got, T_exp, rtol=1e-10, atol=1e-10)
     print_timer(timer_start, caller='test_smooth_field_remap_is_accurate')
   # ------------------------------------------------------------------------
+  def test_dimension_order_is_preserved(self):
+    """
+    the remapped fields must keep the source dimension order (time,lev,ncol).
+    xarray.apply_ufunc moves core dims to the last axis, which silently produced
+    (time,ncol,lev) output - EAM reads initial conditions positionally and does not
+    validate the layout, so a transposed IC blows up in the dycore on the first step
+    instead of raising an error. Assert the layout explicitly rather than calling
+    .transpose() first, which is what let this regression through before.
+    """
+    timer_start = perf_counter()
+    remap_vertical_py(self.src_file, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(self.out_file) as ds_out:
+      for var in ['T','Q']:
+        self.assertEqual(ds_out[var].dims, ('time','lev','ncol'),
+                         msg=f'{var} dims {ds_out[var].dims} != source order (time,lev,ncol)')
+      self.assertEqual(ds_out['PS'].dims, ('time','ncol'))
+    print_timer(timer_start, caller='test_dimension_order_is_preserved')
+  # ------------------------------------------------------------------------
+  def test_dimension_order_is_preserved_for_transposed_source(self):
+    """
+    a source written as (time,ncol,lev) must come back as (time,ncol,lev) - the remap
+    should mirror whatever layout it was handed, not impose one of its own
+    """
+    timer_start = perf_counter()
+    src_file = os.path.join(self.tmpdir, 'src_transposed.nc')
+    self.ds_src.transpose('time','ncol','lev').to_netcdf(src_file)
+    remap_vertical_py(src_file, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(self.out_file) as ds_out:
+      for var in ['T','Q']:
+        self.assertEqual(ds_out[var].dims, ('time','ncol','lev'),
+                         msg=f'{var} dims {ds_out[var].dims} != source order (time,ncol,lev)')
+    print_timer(timer_start, caller='test_dimension_order_is_preserved_for_transposed_source')
+  # ------------------------------------------------------------------------
   def test_passthrough_variables_unchanged(self):
     """
     variables without the source lev dim (PS, TS) should be copied through bit-identical


### PR DESCRIPTION
This pull request introduces important improvements to dimension order validation and handling in the HICCUP codebase, addressing a subtle but critical regression where initial condition files with transposed dimensions could silently cause model failures. The changes add robust checks to ensure that variable dimension order matches expectations, update the vertical remapping logic to preserve source layout, and extend unit tests to cover these cases and the handling of target model names.

**Dimension order validation and enforcement:**

* Added a new `check_dimension_order` method to `hiccup_data_class.py` that verifies variables in a dataset use the expected relative dimension order, preventing silent errors from transposed fields in initial conditions. (`hiccup/hiccup_data_class.py`, [hiccup/hiccup_data_class.pyR1501-R1542](diffhunk://#diff-b26443320ec5ab494eb1d77436b8bf9d339321c334ae835901c176e7af5e6267R1501-R1542))
* Integrated dimension order checks into the `combine_files` method, with logic to set the expected order per target model and validate before writing output files. (`hiccup/hiccup_data_class.py`, [[1]](diffhunk://#diff-b26443320ec5ab494eb1d77436b8bf9d339321c334ae835901c176e7af5e6267R1562-L1539) [[2]](diffhunk://#diff-b26443320ec5ab494eb1d77436b8bf9d339321c334ae835901c176e7af5e6267R1641-R1646)

**Vertical remapping fixes:**

* Updated the vertical remapping kernel to restore the original dimension order after applying `xarray.apply_ufunc`, ensuring remapped fields retain the source layout. (`hiccup/hiccup_vertical_remap.py`, [hiccup/hiccup_vertical_remap.pyR150-R158](diffhunk://#diff-5c5f05d795f4041ef80b8d822cc622729ae526a5a4c9ddb53691c04db6fb6e15R150-R158))

**Target model name handling:**

* Refactored `verify_target_model` to support case-insensitive matching and normalization to canonical spellings, including support for the mixed-case "EAMXX-nudging". (`hiccup/hiccup.py`, [[1]](diffhunk://#diff-667a60b3e3075e8ccc0bd76264e76450da6f9f224a3443c0b0a8398dfb6ef845R14-R17) [[2]](diffhunk://#diff-667a60b3e3075e8ccc0bd76264e76450da6f9f224a3443c0b0a8398dfb6ef845L89-R103)

**Expanded unit tests:**

* Added comprehensive tests covering dimension order checking, handling of extra/unexpected dimensions, support for `ncol_d`, and robust verification of target model name normalization and error handling. (`test_scripts/unit_test_data_class.py`, [test_scripts/unit_test_data_class.pyR474-R577](diffhunk://#diff-d2e296b8df33614a33295aafa04eb80e10b7d55efa194cbbf23b7c50b8461ad2R474-R577))
* Added tests to ensure vertical remapping preserves dimension order for both standard and transposed source layouts. (`test_scripts/unit_test_vertical_remap.py`, [test_scripts/unit_test_vertical_remap.pyR384-R416](diffhunk://#diff-48838d378198c7058fdfb13259f6a9b0fe59cc8566cf7a6289fb96c550df50f9R384-R416))