### PR TITLE
add automatic detection for lrg2sml/a2o flag

### DIFF
--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -474,11 +474,11 @@ class hiccup_data(object):
         if src_type is not None and src_type not in ['FV','GLL']:
             raise ValueError(f'The value of src_type={src_type} is not supported')
         if dst_type is not None and dst_type not in ['FV','GLL']:
-            raise ValueError(f'The value of src_type={src_type} is not supported')
+            raise ValueError(f'The value of dst_type={dst_type} is not supported')
 
         # Determine whether the grid arguments passed to GenerateOverlapMesh
         # need to be swapped (i.e. dst grid is finer than the src grid)
-        if lrg2sml is None: lrg2sml = self.check_lrg2sml()
+        if lrg2sml is None: lrg2sml = self.check_lrg2sml(verbose=verbose)
 
         # Set the mapping algorithm
         if src_type=='FV' and dst_type=='GLL': alg_flag = '-a fv2se_flx'

--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -184,6 +184,7 @@ class hiccup_data(object):
     from hiccup.hiccup_data_class_grid_methods import get_dst_grid_ne
     from hiccup.hiccup_data_class_grid_methods import get_dst_grid_npg
     from hiccup.hiccup_data_class_grid_methods import get_dst_grid_ncol
+    from hiccup.hiccup_data_class_grid_methods import check_lrg2sml
     # --------------------------------------------------------------------------
     # Import SST/sea-ice methods
     from hiccup.hiccup_data_class_sstice_methods import get_sst_file
@@ -449,11 +450,12 @@ class hiccup_data(object):
         if print_memory_usage: self.print_mem_usage(msg=f'after {sys._getframe(0).f_code.co_name}')
         return 
     # --------------------------------------------------------------------------
-    def create_map_file(self,verbose=None,src_type=None,dst_type=None,lrg2sml=False):
+    def create_map_file(self,verbose=None,src_type=None,dst_type=None,lrg2sml=None):
         """ 
         Generate mapping file after grid files have been created.
         This routine assumes that the destination is always GLL/np4.
-        For mapping EAM to EAM data this method is overloaded below. 
+        For mapping EAM to EAM data this method is overloaded below.
+        The lrg2sml argument is determined automatically if not specified.
         """
         if print_memory_usage: self.print_mem_usage(msg=f'before {sys._getframe(0).f_code.co_name}')
         if self.do_timers: timer_start = perf_counter()
@@ -474,6 +476,10 @@ class hiccup_data(object):
         if dst_type is not None and dst_type not in ['FV','GLL']:
             raise ValueError(f'The value of src_type={src_type} is not supported')
 
+        # Determine whether the grid arguments passed to GenerateOverlapMesh
+        # need to be swapped (i.e. dst grid is finer than the src grid)
+        if lrg2sml is None: lrg2sml = self.check_lrg2sml()
+
         # Set the mapping algorithm
         if src_type=='FV' and dst_type=='GLL': alg_flag = '-a fv2se_flx'
         if src_type=='GLL'and dst_type=='GLL': alg_flag = '-a se2se'
@@ -485,7 +491,8 @@ class hiccup_data(object):
         cmd += f' --src_grd={self.src_grid_file}'
         cmd += f' --dst_grd={self.dst_grid_file}'
         cmd += f' --map_file={self.map_file}'
-        if lrg2sml: cmd += ' --lrg2sml ' # special flag for "very fine" grids 
+        cmd += f' --tmp_dir={self.tmp_dir}'
+        if lrg2sml: cmd += ' --lrg2sml ' # special flag for "very fine" grids (--a2o, --atm2ocn, --b2l, --big2ltl, --l2s)
         run_cmd(cmd,verbose,shell=True)
 
         if self.do_timers: self.print_timer(timer_start)

--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -491,7 +491,7 @@ class hiccup_data(object):
         cmd += f' --src_grd={self.src_grid_file}'
         cmd += f' --dst_grd={self.dst_grid_file}'
         cmd += f' --map_file={self.map_file}'
-        cmd += f' --tmp_dir={self.tmp_dir}'
+        if self.tmp_dir is not None: cmd += f' --tmp_dir={self.tmp_dir}'
         if lrg2sml: cmd += ' --lrg2sml ' # special flag for "very fine" grids (--a2o, --atm2ocn, --b2l, --big2ltl, --l2s)
         run_cmd(cmd,verbose,shell=True)
 

--- a/hiccup/hiccup_data_class_grid_methods.py
+++ b/hiccup/hiccup_data_class_grid_methods.py
@@ -69,3 +69,32 @@ def get_dst_grid_ncol(self):
         if npg>0 : ncol = int(ne*ne*6*npg)
     return ncol
 # ------------------------------------------------------------------------------
+def get_grid_cell_count(grid_file):
+    """
+    Return the number of cells/elements in a SCRIP or exodus grid file
+    """
+    cell_dim_list = ['grid_size','num_elem','elementCount','ncol']
+    with xr.open_dataset(grid_file,decode_cf=False) as ds_grid:
+        for dim in cell_dim_list:
+            if dim in ds_grid.sizes: return int(ds_grid.sizes[dim])
+    raise ValueError(f'get_grid_cell_count: could not determine the number of cells'
+                     f' in {grid_file} - expected one of these dimensions: {cell_dim_list}')
+# ------------------------------------------------------------------------------
+def check_lrg2sml(self,src_grid_file=None,dst_grid_file=None,verbose=None):
+    """
+    Determine whether the ncremap --lrg2sml flag is needed. This flag swaps the
+    order of the grid arguments given to GenerateOverlapMesh, which requires the
+    grid with the smaller cells to come first, so the flag is needed whenever the
+    destination grid is finer than the source grid (i.e. "very fine" RRM grids).
+    """
+    if verbose is None: verbose = self.verbose
+    if src_grid_file is None: src_grid_file = self.src_grid_file
+    if dst_grid_file is None: dst_grid_file = self.dst_grid_file
+    src_cell_cnt = get_grid_cell_count(src_grid_file)
+    dst_cell_cnt = get_grid_cell_count(dst_grid_file)
+    lrg2sml = dst_cell_cnt > src_cell_cnt
+    if verbose:
+        print(f'{self.verbose_indent}  src grid cells: {src_cell_cnt}'
+              f' / dst grid cells: {dst_cell_cnt} => lrg2sml = {lrg2sml}')
+    return lrg2sml
+# ------------------------------------------------------------------------------

--- a/hiccup/hiccup_data_subclass_EAM.py
+++ b/hiccup/hiccup_data_subclass_EAM.py
@@ -268,7 +268,7 @@ class EAM(hiccup_data):
         cmd += f' --src_grd={self.src_grid_file_np}'
         cmd += f' --dst_grd={self.dst_grid_file_np}'
         cmd += f' --map_file={self.map_file_np}'
-        if self.check_lrg2sml(self.src_grid_file_np,self.dst_grid_file_np):
+        if self.check_lrg2sml(self.src_grid_file_np,self.dst_grid_file_np,verbose=verbose):
             cmd += ' --lrg2sml '
         run_cmd(cmd,verbose,shell=True)
 

--- a/hiccup/hiccup_data_subclass_EAM.py
+++ b/hiccup/hiccup_data_subclass_EAM.py
@@ -257,9 +257,6 @@ class EAM(hiccup_data):
 
         check_dependency('ncremap')
 
-        dst_ne = self.get_dst_grid_ne()
-        src_ne = self.get_src_grid_ne()
-
         # Check that grid file fields are not empty
         if self.src_grid_file_np is None : raise ValueError('src_grid_file_np is not defined!')
         if self.src_grid_file_pg is None : raise ValueError('src_grid_file_pg is not defined!')
@@ -271,7 +268,8 @@ class EAM(hiccup_data):
         cmd += f' --src_grd={self.src_grid_file_np}'
         cmd += f' --dst_grd={self.dst_grid_file_np}'
         cmd += f' --map_file={self.map_file_np}'
-        if dst_ne>src_ne : cmd += ' --lrg2sml '
+        if self.check_lrg2sml(self.src_grid_file_np,self.dst_grid_file_np):
+            cmd += ' --lrg2sml '
         run_cmd(cmd,verbose,shell=True)
 
         # Create the pgN map file
@@ -279,7 +277,8 @@ class EAM(hiccup_data):
         cmd += f' --src_grd={self.src_grid_file_pg}'
         cmd += f' --dst_grd={self.dst_grid_file_pg}'
         cmd += f' --map_file={self.map_file_pg}'
-        if dst_ne>src_ne : cmd += ' --lrg2sml '
+        if self.check_lrg2sml(self.src_grid_file_pg,self.dst_grid_file_pg):
+            cmd += ' --lrg2sml '
         run_cmd(cmd,verbose,shell=True)
 
         if self.do_timers: self.print_timer(timer_start)


### PR DESCRIPTION
This pull request improves the logic for determining when to use the `--lrg2sml` flag in mapping file generation, making it more robust and automatic. The main changes include introducing a new utility to check grid cell counts, updating the logic in both the base and EAM-specific mapping routines, and ensuring the flag is set based on actual grid resolution rather than relying on user input or grid NE values.

**Enhancements to grid mapping logic:**

* Added a new `check_lrg2sml` method in `hiccup_data_class_grid_methods.py` to automatically determine if the `--lrg2sml` flag should be used, based on the number of cells in the source and destination grids, using the new `get_grid_cell_count` helper.
* Updated the `create_map_file` method in `hiccup_data_class.py` to use the new `check_lrg2sml` logic, setting the `lrg2sml` argument automatically if not specified, and passing the flag to the mapping command as appropriate. [[1]](diffhunk://#diff-b26443320ec5ab494eb1d77436b8bf9d339321c334ae835901c176e7af5e6267L452-R458) [[2]](diffhunk://#diff-b26443320ec5ab494eb1d77436b8bf9d339321c334ae835901c176e7af5e6267R479-R482) [[3]](diffhunk://#diff-b26443320ec5ab494eb1d77436b8bf9d339321c334ae835901c176e7af5e6267L488-R495)

**Refactoring and consistency improvements:**

* Modified the EAM-specific `create_map_file` in `hiccup_data_subclass_EAM.py` to use `check_lrg2sml` for both NP and PG grid types, replacing the previous logic that compared NE values. [[1]](diffhunk://#diff-a95b08c98c150e7a726c6fee32aa23b6af1ade40cb8507b2ceefb53af43e199fL260-L262) [[2]](diffhunk://#diff-a95b08c98c150e7a726c6fee32aa23b6af1ade40cb8507b2ceefb53af43e199fL274-R281)
* Updated imports in `hiccup_data_class.py` to include the new `check_lrg2sml` method.

These changes make the mapping file creation process more reliable and less error-prone, especially for cases involving "very fine" grids where the destination has more cells than the source.