### PR TITLE
add stage_multifile methods to address edge case

### DIFF
--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -906,7 +906,111 @@ class hiccup_data(object):
 
         if self.do_timers: self.print_timer(timer_start)
         if print_memory_usage: self.print_mem_usage(msg=f'after {sys._getframe(0).f_code.co_name}')
-        return 
+        return
+    # --------------------------------------------------------------------------
+    def stage_multifile(self,file_dict,verbose=None,target_time=None):
+        """
+        Copy each variable into its own temporary file using the same "multifile"
+        layout as remap_horizontal_multifile(), but without performing any
+        horizontal regridding. Use this in place of remap_horizontal_multifile()
+        when the destination horizontal grid is identical to the source grid
+        (e.g. converting EAM data to EAMxx format on the same mesh) but the data
+        still needs to pass through methods that expect the multifile layout,
+        like surface_adjustment_multifile().
+        """
+        if print_memory_usage: self.print_mem_usage(msg=f'before {sys._getframe(0).f_code.co_name}')
+        if self.do_timers: timer_start = perf_counter()
+        if verbose is None: verbose = self.verbose
+        if verbose: print(f'\n{self.verbose_indent}Staging multi-file data to temporary files (no horizontal remap)...')
+
+        if len(self.input_file_list) == 0: raise ValueError('input_file_list cannot be empty!')
+
+        lat_var = self.atm_var_name_dict['lat'] if 'lat' in self.atm_var_name_dict else None
+        lon_var = self.atm_var_name_dict['lon'] if 'lon' in self.atm_var_name_dict else None
+
+        # check that input data has valid _FillValue (i.e. not NaN) and if not
+        # create a copy with modified metadata; rebuild var-to-file map if paths changed
+        new_list = [self.check_file_FillValue(f) for f in self.input_file_list]
+        if new_list != self.input_file_list:
+            self.input_file_list = new_list
+            self._build_var_to_file_map()
+
+        all_var_dicts = {**self.atm_var_name_dict, **self.sfc_var_name_dict}
+
+        # Copy atmosphere and surface data to individual files (no regridding)
+        for var,tmp_file_name in file_dict.items():
+            in_file = self._var_to_file_map[var]
+            in_var  = all_var_dicts[var]
+            # Remove temporary files if they exist
+            if os.path.isfile(tmp_file_name): run_cmd(f'rm {tmp_file_name}',verbose)
+            with xr.open_dataset(in_file,chunks=self.get_chunks()) as ds:
+                keep_vars = [in_var] + [v for v in [lat_var,lon_var] if v is not None and v in ds.variables]
+                ds_out = ds[keep_vars]
+                if target_time is not None and 'time' in ds_out.dims:
+                    time_idx = self._get_time_index(in_file,target_time)
+                    ds_out = ds_out.isel(time=[time_idx])
+                ds_out.to_netcdf(tmp_file_name,format=xarray_atm_nc_format,mode='w')
+
+        if self.do_timers: self.print_timer(timer_start)
+        if print_memory_usage: self.print_mem_usage(msg=f'after {sys._getframe(0).f_code.co_name}')
+        return
+    # --------------------------------------------------------------------------
+    def stage_multifile_eam(self,file_dict,verbose=None,target_time=None):
+        """
+        Copy each variable into its own temporary file using the same "multifile"
+        layout as remap_horizontal_multifile_eam(), but without performing any
+        horizontal regridding. Use this in place of remap_horizontal_multifile_eam()
+        when the destination horizontal grid is identical to the source grid
+        (e.g. converting EAM data to EAMxx format on the same mesh) but the data
+        still needs to pass through methods that expect the multifile layout,
+        like surface_adjustment_multifile().
+        """
+        if print_memory_usage: self.print_mem_usage(msg=f'before {sys._getframe(0).f_code.co_name}')
+        if self.do_timers: timer_start = perf_counter()
+        if verbose is None: verbose = self.verbose
+        if verbose: print(f'\n{self.verbose_indent}Staging multi-file data to temporary files (no horizontal remap)...')
+
+        if len(self.input_file_list) == 0: raise ValueError('input_file_list cannot be empty!')
+
+        # check that input data has valid _FillValue (i.e. not NaN) and if not
+        # create a copy with modified metadata; rebuild var-to-file map if paths changed
+        new_list = [self.check_file_FillValue(f) for f in self.input_file_list]
+        if new_list != self.input_file_list:
+            self.input_file_list = new_list
+            self._build_var_to_file_map()
+
+        # Copy atmosphere and surface data to individual files (no regridding)
+        for var,tmp_file_name in file_dict.items():
+            in_var  = var
+            in_file = self._var_to_file_map.get(var, self.input_file_list[0])
+            # Remove temporary files if they exist
+            if os.path.isfile(tmp_file_name): run_cmd(f'rm {tmp_file_name}',verbose)
+            with xr.open_dataset(in_file,chunks=self.get_chunks()) as ds:
+                # always try to carry lat/lon along, since remap_horizontal_multifile_eam
+                # gets these "for free" from the map file regardless of --var_lst
+                keep_vars = [in_var] + [v for v in ['lat','lon'] if v in ds.variables]
+                ds_out = ds[keep_vars]
+                if target_time is not None and 'time' in ds_out.dims:
+                    time_idx = self._get_time_index(in_file,target_time)
+                    ds_out = ds_out.isel(time=[time_idx])
+                ds_out.to_netcdf(tmp_file_name,format=xarray_atm_nc_format,mode='w')
+
+        # get rid of bounds and vertices variables
+        # (mirrors the cleanup in remap_horizontal_multifile_eam)
+        for var,tmp_file_name in file_dict.items():
+            with xr.open_dataset(tmp_file_name) as ds:
+                ds.load()
+                if 'lat' in ds and 'bounds' in ds['lat'].attrs : del ds['lat'].attrs['bounds']
+                if 'lon' in ds and 'bounds' in ds['lon'].attrs : del ds['lon'].attrs['bounds']
+                if 'lat_vertices' in ds.variables: ds = ds.drop('lat_vertices')
+                if 'lon_vertices' in ds.variables: ds = ds.drop('lon_vertices')
+                ds.to_netcdf(f'{tmp_file_name}.hiccup_tmp',format=xarray_atm_nc_format,mode='w')
+                ds.close()
+            run_cmd(f'mv {tmp_file_name}.hiccup_tmp {tmp_file_name}',verbose)
+
+        if self.do_timers: self.print_timer(timer_start)
+        if print_memory_usage: self.print_mem_usage(msg=f'after {sys._getframe(0).f_code.co_name}')
+        return
     # --------------------------------------------------------------------------
     def surface_adjustment_multifile(self,file_dict,verbose=None,
                                     adj_TS=False,adj_PS=True,adj_T_eam=False):

--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -937,6 +937,9 @@ class hiccup_data(object):
 
         all_var_dicts = {**self.atm_var_name_dict, **self.sfc_var_name_dict}
 
+        # Cache time indices per file to avoid repeatedly opening the same file
+        time_idx_cache = {}
+
         # Copy atmosphere and surface data to individual files (no regridding)
         for var,tmp_file_name in file_dict.items():
             in_file = self._var_to_file_map[var]
@@ -947,8 +950,13 @@ class hiccup_data(object):
                 keep_vars = [in_var] + [v for v in [lat_var,lon_var] if v is not None and v in ds.variables]
                 ds_out = ds[keep_vars]
                 if target_time is not None and 'time' in ds_out.dims:
-                    time_idx = self._get_time_index(in_file,target_time)
-                    ds_out = ds_out.isel(time=[time_idx])
+                    if in_file not in time_idx_cache:
+                        with xr.open_dataset(in_file, decode_times=False) as ds_tmp:
+                            if 'time' in ds_tmp.dims:
+                                times = xr.decode_cf(ds_tmp)['time'].values
+                                time_idx_cache[in_file] = pd.DatetimeIndex(times).get_loc(pd.Timestamp(target_time))
+                    if in_file in time_idx_cache:
+                        ds_out = ds_out.isel(time=[time_idx_cache[in_file]])
                 ds_out.to_netcdf(tmp_file_name,format=xarray_atm_nc_format,mode='w')
 
         if self.do_timers: self.print_timer(timer_start)

--- a/template_hiccup_scripts/create_EAMxx_IC_from_EAM.horz+vert.py
+++ b/template_hiccup_scripts/create_EAMxx_IC_from_EAM.horz+vert.py
@@ -35,6 +35,16 @@ do_sfc_adjust   = True    # perform surface T and P adjustments
 remap_data_vert = True    # vertical remap
 do_state_adjust = True    # post vertical interpolation adjustments
 combine_files   = True    # combine temporary data files and delete
+
+# Set this to True when dst_horz_grid is the same mesh as the source EAM data
+# (e.g. converting an EAM file to EAMxx format without changing resolution).
+# This skips grid/map file creation and the actual horizontal regrid, using
+# stage_multifile() in place of remap_horizontal_multifile() to put the data
+# in the "multifile" layout that surface_adjustment_multifile() still needs
+# (useful here because EAM and EAMxx topography files often use different
+# amounts of smoothing, so surface_adjustment_multifile() is still required
+# even though no horizontal regridding is actually needed).
+same_horz_grid  = False
 # ------------------------------------------------------------------------------
 # HICCUP uses two independent path roots:
 #   hiccup_root - path to your local HICCUP repo, only used to locate the bundled
@@ -93,7 +103,8 @@ file_dict = hiccup_data.get_multifile_dict(timestamp=timestamp)
 # ------------------------------------------------------------------------------
 # Create grid and mapping files
 if 'create_map_file' not in locals(): create_map_file = False
-if create_map_file :
+if 'same_horz_grid' not in locals(): same_horz_grid = False
+if create_map_file and not same_horz_grid :
 
     # Create grid description files needed for the mapping file
     hiccup_data.create_src_grid_file()
@@ -107,9 +118,13 @@ if create_map_file :
 if 'remap_data_horz' not in locals(): remap_data_horz = False
 if remap_data_horz :
 
-    # Horizontally regrid np4 data
-    hiccup_data.map_file = hiccup_data.map_file_np
-    hiccup_data.remap_horizontal_multifile(file_dict=file_dict)
+    if same_horz_grid :
+        # Same mesh - just stage the data into per-variable files, no regrid
+        hiccup_data.stage_multifile(file_dict=file_dict)
+    else :
+        # Horizontally regrid np4 data
+        hiccup_data.map_file = hiccup_data.map_file_np
+        hiccup_data.remap_horizontal_multifile(file_dict=file_dict)
 
     # Rename variables to match what the model expects
     hiccup_data.rename_vars_multifile(file_dict=file_dict)

--- a/test_scripts/unit_test_data_class.py
+++ b/test_scripts/unit_test_data_class.py
@@ -225,6 +225,89 @@ class hiccup_data_class_test_case(unittest.TestCase):
                       msg=f'Expected .nc path for key {key!r}, got {file_dict[key]!r}')
     print_timer(timer_start,caller='test_hiccup_data_class_get_multifile_dict_eam')
   # ----------------------------------------------------------------------------
+  def test_hiccup_data_class_stage_multifile(self):
+    """
+    verify stage_multifile() copies each variable into the multifile layout
+    (same file_dict paths as remap_horizontal_multifile()) without performing
+    any horizontal remap
+    """
+    timer_start = perf_counter()
+    obj = self.hiccup_data_ERA5
+    file_dict = obj.get_multifile_dict(timestamp='stagetest')
+    try:
+      obj.stage_multifile(file_dict=file_dict)
+      all_var_dicts = {**obj.atm_var_name_dict, **obj.sfc_var_name_dict}
+      lat_var = obj.atm_var_name_dict['lat']
+      lon_var = obj.atm_var_name_dict['lon']
+      for key, path in file_dict.items():
+        self.assertTrue(os.path.isfile(path), msg=f'stage_multifile did not create {path}')
+        src_var = all_var_dicts[key]
+        with xr.open_dataset(path) as ds_out:
+          self.assertIn(src_var, ds_out.variables,
+                        msg=f'{src_var} missing from staged file for {key!r}')
+          self.assertIn(lat_var, ds_out.variables, msg='lat missing from staged file')
+          self.assertIn(lon_var, ds_out.variables, msg='lon missing from staged file')
+      # spot check that the data itself was copied through unchanged
+      src_path = obj._var_to_file_map['T']
+      with xr.open_dataset(src_path) as ds_src, xr.open_dataset(file_dict['T']) as ds_T:
+        np.testing.assert_allclose(ds_T['t'].values, ds_src['t'].values)
+    finally:
+      for path in file_dict.values():
+        if os.path.isfile(path): os.remove(path)
+    print_timer(timer_start,caller='test_hiccup_data_class_stage_multifile')
+  # ----------------------------------------------------------------------------
+  def test_hiccup_data_class_stage_multifile_eam(self):
+    """
+    verify stage_multifile_eam() copies each variable into the multifile layout
+    (same file_dict paths as remap_horizontal_multifile_eam()) without performing
+    any horizontal remap, using identity-named ("EAM-style") source variables
+    """
+    timer_start = perf_counter()
+    obj = self.hiccup_data_ERA5   # reuse a real object; stage_multifile_eam is generic
+
+    # build a small synthetic "EAM-style" source file (identity-named variables,
+    # unlike ERA5 test data where e.g. 'T' is stored as 't')
+    ncol = 4
+    ds_in = xr.Dataset({
+      'T':   (('ncol',), np.arange(ncol, dtype='float64')),
+      'PS':  (('ncol',), np.arange(ncol, dtype='float64')*10.),
+      'lat': (('ncol',), np.linspace(-1,1,ncol)),
+      'lon': (('ncol',), np.linspace(0,2,ncol)),
+    })
+    tmp_in = tempfile.NamedTemporaryFile(suffix='.nc', delete=False)
+    tmp_in.close()
+    # disable xarray's default NaN _FillValue so check_file_FillValue() doesn't
+    # decide to write a "modified" copy and rebuild _var_to_file_map on us
+    no_fill_encoding = {v: {'_FillValue': None} for v in ds_in.data_vars}
+    ds_in.to_netcdf(tmp_in.name, encoding=no_fill_encoding)
+
+    file_dict = {'T':  os.path.join(obj.tmp_dir,'stage_eam_test.T.nc'),
+                 'PS': os.path.join(obj.tmp_dir,'stage_eam_test.PS.nc')}
+
+    orig_input_file_list = obj.input_file_list
+    orig_var_to_file_map = obj._var_to_file_map
+    try:
+      obj.input_file_list  = [tmp_in.name]
+      obj._var_to_file_map = {'T': tmp_in.name, 'PS': tmp_in.name}
+
+      obj.stage_multifile_eam(file_dict=file_dict)
+
+      for key, path in file_dict.items():
+        self.assertTrue(os.path.isfile(path), msg=f'stage_multifile_eam did not create {path}')
+        with xr.open_dataset(path) as ds_out:
+          self.assertIn(key, ds_out.variables, msg=f'{key} missing from staged file')
+          self.assertIn('lat', ds_out.variables, msg='lat missing from staged file')
+          self.assertIn('lon', ds_out.variables, msg='lon missing from staged file')
+          np.testing.assert_allclose(ds_out[key].values, ds_in[key].values)
+    finally:
+      obj.input_file_list  = orig_input_file_list
+      obj._var_to_file_map = orig_var_to_file_map
+      os.remove(tmp_in.name)
+      for path in file_dict.values():
+        if os.path.isfile(path): os.remove(path)
+
+    print_timer(timer_start,caller='test_hiccup_data_class_stage_multifile_eam')
+  # ----------------------------------------------------------------------------
   def test_parse_version(self):
     """
     test that parse_version correctly parses version strings with and without suffixes


### PR DESCRIPTION
This pull request introduces new functionality to support workflows where the horizontal grid remains unchanged between source and destination datasets, such as when converting EAM data to EAMxx format on the same mesh. Two new methods, `stage_multifile` and `stage_multifile_eam`, are added to the `hiccup_data_class.py` to stage data into the required multifile layout without performing horizontal regridding. The template script and unit tests are updated to utilize and verify this new functionality.

**New staging methods for unchanged horizontal grids:**

* Added `stage_multifile` and `stage_multifile_eam` methods to `hiccup/hiccup_data_class.py`, enabling variables to be copied into the multifile layout without horizontal regridding, for use cases where the source and destination grids are identical.

**Template script enhancements:**

* Updated `template_hiccup_scripts/create_EAMxx_IC_from_EAM.horz+vert.py` to introduce a `same_horz_grid` flag, allowing users to skip grid/map file creation and use the new staging methods when the horizontal grid does not change.
* Modified logic in the template script to call `stage_multifile` instead of horizontal regridding when `same_horz_grid` is set, and to skip unnecessary map file creation. [[1]](diffhunk://#diff-564c5f5691503dc7f493130dc1931430d4952cd499360bf8f1c3a9de78d57af3L96-R107) [[2]](diffhunk://#diff-564c5f5691503dc7f493130dc1931430d4952cd499360bf8f1c3a9de78d57af3R121-R124)

**Unit testing improvements:**

* Added unit tests for both `stage_multifile` and `stage_multifile_eam` to `test_scripts/unit_test_data_class.py`, ensuring correct multifile staging and data integrity in both generic and EAM-style scenarios.