### PR TITLE
update combine_files defaults

### DIFF
--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -1696,14 +1696,14 @@ class hiccup_data(object):
             if expected_dim_list is None: expected_dim_list = ['time','lev','ncol']
             if combine_uv is None: combine_uv = False
         if self.target_model=='EAMXX':
-            u_name,v_name,uv_name = 'horiz_winds_u','horiz_winds_v','horiz_winds'
+            u_name,v_name,uv_name = 'U','V','horiz_winds'
             if use_single_precision is None: use_single_precision = True
             if permute_dimensions is None: permute_dimensions = True
             if permute_dim_list is None:permute_dim_list = ['time','ncol','lev']
             if expected_dim_list is None: expected_dim_list = permute_dim_list
-            if combine_uv is None: combine_uv = True
+            # if combine_uv is None: combine_uv = True
         if self.target_model=='EAMXX-nudging':
-            u_name,v_name,uv_name = 'horiz_winds_u','horiz_winds_v','horiz_winds'
+            u_name,v_name,uv_name = 'U','V','horiz_winds'
             if use_single_precision is None: use_single_precision = True
             if permute_dimensions is None: permute_dimensions = True
             if permute_dim_list is None: permute_dim_list = ['time','ncol','lev']

--- a/hiccup/hiccup_data_subclass_EAM.py
+++ b/hiccup/hiccup_data_subclass_EAM.py
@@ -136,8 +136,8 @@ class EAM(hiccup_data):
             self.atm_var_name_dict.update({'lon':'lon'})
             self.atm_var_name_dict.update({'T_mid':'T'})                # temperature
             self.atm_var_name_dict.update({'qv':'Q'})                   # specific humidity
-            self.atm_var_name_dict.update({'horiz_winds_u':'U'})        # zonal wind
-            self.atm_var_name_dict.update({'horiz_winds_v':'V'})        # meridional wind
+            self.atm_var_name_dict.update({'U':'U'})                    # zonal wind
+            self.atm_var_name_dict.update({'V':'V'})                    # meridional wind
             self.atm_var_name_dict.update({'o3_volume_mix_ratio':'O3'}) # ozone mass mixing ratio
             self.atm_var_name_dict.update({'qc':'CLDLIQ'})              # specific cloud liq water
             self.atm_var_name_dict.update({'qi':'CLDICE'})              # specific cloud ice water

--- a/hiccup/hiccup_data_subclass_ERA5.py
+++ b/hiccup/hiccup_data_subclass_ERA5.py
@@ -107,8 +107,8 @@ class ERA5(hiccup_data):
             self.atm_var_name_dict.update({'lon':'longitude'})
             self.atm_var_name_dict.update({'T_mid':'t'})                # temperature
             self.atm_var_name_dict.update({'qv':'q'})                   # specific humidity
-            self.atm_var_name_dict.update({'horiz_winds_u':'u'})        # zonal wind
-            self.atm_var_name_dict.update({'horiz_winds_v':'v'})        # meridional wind
+            self.atm_var_name_dict.update({'U':'u'})                    # zonal wind
+            self.atm_var_name_dict.update({'V':'v'})                    # meridional wind
             self.atm_var_name_dict.update({'qc':'clwc'})                # specific cloud liq water
             self.atm_var_name_dict.update({'qi':'ciwc'})                # specific cloud ice water
             self.atm_var_name_dict.update({'o3_volume_mix_ratio':'o3'}) # ozone mass mixing ratio


### PR DESCRIPTION
This pull request standardizes the naming conventions for wind variables across the codebase, updating both internal and external variable mappings to consistently use `U` and `V` for zonal and meridional winds. This change affects how wind variables are referenced and mapped in both EAM and ERA5 data handling classes, as well as in the file combination logic.

**Variable naming standardization:**

* Updated `hiccup_data_class.py` so that for `EAMXX` and `EAMXX-nudging` models, the internal wind variable names are set to `U` and `V` instead of `horiz_winds_u` and `horiz_winds_v`. The default for `combine_uv` is no longer forcibly set to `True` for these models.
* Modified the variable name mapping in `hiccup_data_subclass_EAM.py` to map `U` and `V` (not `horiz_winds_u`/`horiz_winds_v`) to themselves for zonal and meridional winds.
* Modified the variable name mapping in `hiccup_data_subclass_ERA5.py` to map `U` and `V` (not `horiz_winds_u`/`horiz_winds_v`) to the ERA5 wind variables `u` and `v`.…te U/V components by default