### PR TITLE
bug fix

### DIFF
--- a/hiccup/hiccup_data_class.py
+++ b/hiccup/hiccup_data_class.py
@@ -1061,7 +1061,8 @@ class hiccup_data(object):
         # creating a new temporary file is a good way to do this
         if adj_T_eam and adj_PS:
             ps_file = file_dict[var_dict['PS']]
-            ps_old_file = ps_file.replace(var_dict['PS'],'PS_old')
+            ps_dir, ps_base = os.path.split(ps_file)
+            ps_old_file = os.path.join(ps_dir, f'PS_old_{ps_base}')
             run_cmd(f'cp {ps_file} {ps_old_file} ',verbose,shell=True)
 
         file_list = get_adj_file_list(var_dict.values(),file_dict)


### PR DESCRIPTION
This pull request updates the `surface_adjustment_multifile` function in `hiccup/hiccup_data_class.py` to improve how backup files are named when copying the `PS` file. Instead of replacing the filename with a generic `PS_old`, the backup now uses a more descriptive format that includes the original filename, reducing the risk of overwriting files and making backups easier to identify.

File handling improvements:

* Changed the backup file naming convention in `flip_lev` to prefix the original `PS` filename with `PS_old_`, making backups clearer and less error-prone.