### PR TITLE
Update EAM subclass var dict

### DIFF
--- a/hiccup/hiccup_data_subclass_EAM.py
+++ b/hiccup/hiccup_data_subclass_EAM.py
@@ -141,6 +141,10 @@ class EAM(hiccup_data):
             self.atm_var_name_dict.update({'o3_volume_mix_ratio':'O3'}) # ozone mass mixing ratio
             self.atm_var_name_dict.update({'qc':'CLDLIQ'})              # specific cloud liq water
             self.atm_var_name_dict.update({'qi':'CLDICE'})              # specific cloud ice water
+            self.atm_var_name_dict.update({'qr':'RAINQM'})              # rain water
+            self.atm_var_name_dict.update({'nc':'NUMLIQ'})              # cloud liquid number concentration
+            self.atm_var_name_dict.update({'ni':'NUMICE'})              # cloud ice number concentration
+            self.atm_var_name_dict.update({'nr':'NUMRAI'})              # rain number concentration
             self.sfc_var_name_dict.update({'ps':'PS'})                  # sfc pressure
             self.sfc_var_name_dict.update({'phis':'PHIS'})              # surface geopotential
 


### PR DESCRIPTION
This pull request adds several new atmospheric variable mappings to the `atm_var_name_dict` in the `hiccup_data_subclass_EAM.py` file. These changes expand the set of variables that can be referenced and processed, particularly for cloud and rain microphysics.

**Atmospheric variable mapping additions:**

* Added mappings for rain water (`qr` to `RAINQM`), cloud liquid number concentration (`nc` to `NUMLIQ`), cloud ice number concentration (`ni` to `NUMICE`), and rain number concentration (`nr` to `NUMRAI`) in `atm_var_name_dict` within the `__init__` method of `hiccup_data_subclass_EAM.py`.