### PR TITLE
vert remap bug fix

### DIFF
--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -274,7 +274,9 @@ def remap_vertical_py(input_file, output_file, vert_file,
         f'looks like hPa while the target is Pa. This usually means the source '
         f'file is missing its hybrid coefficients (hyam/hybm/P0) at the vertical '
         f'remap step, so lev={lev_name!r} was used directly as pressure. '
-        f'Add P0 (add_reference_pressure) or set the lev units to Pa/hPa.'
+        f'Fix by adding P0 (add_reference_pressure), setting lev units to hPa/mb '
+        f'(so it can be converted to Pa), or converting lev values to Pa and '
+        f'setting units="Pa".'
       )
 
     # decide which fields get remapped; never remap the hybrid coefficients themselves -

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -49,30 +49,38 @@ def _compute_input_pressure(ds, lev_name, ps):
   """
   return an xarray.DataArray of pressure on the source vertical grid
   detects three layouts:
-    1. EAM / EAMxx hybrid: hyam, hybm present -> p = hyam*P0 + hybm*ps
+    1. EAM / EAMxx hybrid: hyam is a unitless fraction of P0 -> p = hyam*P0 + hybm*ps
        (P0 defaults to _DEFAULT_P0 when absent - EAM/CAM hyam are unitless
        fractions, so a missing P0 must NOT silently drop us to the bare-lev
        fallback, which mixes hPa lev values with a Pa target grid)
-    2. ECMWF IFS hybrid:   hyam in Pa, lnsp present (no P0) -> p = hyam + hybm*ps
+    2. ECMWF IFS hybrid:   hyam is already in Pa -> p = hyam + hybm*ps
     3. pure pressure levels: only the lev coord -> p = ds[lev_name]
        (converted to Pa when the coordinate advertises hPa/millibar units)
+  The EAM vs IFS choice is made from the magnitude of hyam, NOT from the presence
+  of P0 or lnsp: those cues are ambiguous (an IFS file can carry P0 after
+  add_reference_pressure, and an IFS file can supply PS instead of lnsp), and
+  keying off them picks the wrong hybrid formula. hyam as a unitless fraction is
+  O(1); hyam in Pa is O(1e3-1e4), so the two conventions are cleanly separated by
+  several orders of magnitude.
   ps must be the resolved surface pressure DataArray (see _resolve_surface_pressure)
   """
   variables = set(ds.variables.keys())
   hybrid = {'hyam','hybm'}.issubset(variables)
 
-  if hybrid and 'lnsp' in variables:
-    # IFS layout: hyam is already in Pa, no P0 scaling
-    return ds['hyam'] + ds['hybm']*ps
-
   if hybrid:
-    # EAM / EAMxx hybrid: hyam is a unitless fraction of P0. Default P0 when the
-    # file hasn't had add_reference_pressure() applied yet - otherwise the old
-    # code fell through to the bare-lev fallback below and used the hPa-valued
-    # lev coordinate as if it were Pa, clamping everything below ~10 hPa to a
-    # constant.
-    p0 = ds['P0'] if 'P0' in variables else _DEFAULT_P0
-    return ds['hyam']*p0 + ds['hybm']*ps
+    hyam = ds['hyam']
+    hybm = ds['hybm']
+    # unitless fraction (EAM/CAM) vs pressure in Pa (ECMWF IFS); hyam is 1-D over
+    # levels so this max() is cheap even under dask
+    if float(np.asarray(hyam.max())) <= 1.0:
+      # EAM / EAMxx hybrid: hyam is a unitless fraction of P0. Default P0 when the
+      # file hasn't had add_reference_pressure() applied yet - otherwise we'd fall
+      # through to the bare-lev fallback below and use the hPa-valued lev
+      # coordinate as if it were Pa, clamping everything below ~10 hPa to a constant.
+      p0 = ds['P0'] if 'P0' in variables else _DEFAULT_P0
+      return hyam*p0 + hybm*ps
+    # IFS layout: hyam is already in Pa, no P0 scaling
+    return hyam + hybm*ps
 
   if lev_name in ds.coords or lev_name in ds.variables:
     lev = ds[lev_name].astype('float64')

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -265,19 +265,24 @@ def remap_vertical_py(input_file, output_file, vert_file,
     # source pressure ends up as a bare hPa lev coordinate (max ~1000) while the
     # target grid is in Pa (max ~1e5). np.interp would then clamp every level
     # below ~10 hPa to a constant instead of raising - fail loudly instead.
-    p_in_max  = float(np.asarray(p_in.max()))
-    p_out_max = float(np.asarray(p_out.max()))
-    if p_in_max > 0.0 and p_in_max < 1.2e3 and p_out_max > 1.0e4:
-      raise ValueError(
-        f'source vertical pressure (max {p_in_max:.3g}) and target grid '
-        f'(max {p_out_max:.3g} Pa) appear to be in different units - the source '
-        f'looks like hPa while the target is Pa. This usually means the source '
-        f'file is missing its hybrid coefficients (hyam/hybm/P0) at the vertical '
-        f'remap step, so lev={lev_name!r} was used directly as pressure. '
-        f'Fix by adding P0 (add_reference_pressure), setting lev units to hPa/mb '
-        f'(so it can be converted to Pa), or converting lev values to Pa and '
-        f'setting units="Pa".'
-      )
+    # Only relevant to the bare pressure-coordinate fallback: a hybrid source
+    # always yields Pa (hyam*P0 + hybm*ps), so skip the guard there and avoid
+    # eagerly reducing p_in/p_out over large dask arrays before apply_ufunc.
+    src_is_hybrid = {'hyam','hybm'}.issubset(ds_in.variables.keys())
+    if not src_is_hybrid:
+      p_in_max  = float(np.asarray(p_in.max()))
+      p_out_max = float(np.asarray(p_out.max()))
+      if p_in_max > 0.0 and p_in_max < 1.2e3 and p_out_max > 1.0e4:
+        raise ValueError(
+          f'source vertical pressure (max {p_in_max:.3g}) and target grid '
+          f'(max {p_out_max:.3g} Pa) appear to be in different units - the source '
+          f'looks like hPa while the target is Pa. This usually means the source '
+          f'file is missing its hybrid coefficients (hyam/hybm/P0) at the vertical '
+          f'remap step, so lev={lev_name!r} was used directly as pressure. '
+          f'Fix by adding P0 (add_reference_pressure), setting lev units to hPa/mb '
+          f'(so it can be converted to Pa), or converting lev values to Pa and '
+          f'setting units="Pa".'
+        )
 
     # decide which fields get remapped; never remap the hybrid coefficients themselves -
     # those describe the vertical grid and are pulled from vert_file

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -270,8 +270,12 @@ def remap_vertical_py(input_file, output_file, vert_file,
     # eagerly reducing p_in/p_out over large dask arrays before apply_ufunc.
     src_is_hybrid = {'hyam','hybm'}.issubset(ds_in.variables.keys())
     if not src_is_hybrid:
-      p_in_max  = float(np.asarray(p_in.max()))
-      p_out_max = float(np.asarray(p_out.max()))
+      p_in_max = float(np.asarray(p_in.max()))
+      ps_max = float(np.asarray(ps.max()))
+      p0 = float(np.asarray(ds_vert['P0'])) if 'P0' in ds_vert.variables else _DEFAULT_P0
+      hyam_max = float(np.asarray(ds_vert['hyam'].max()))
+      hybm_max = float(np.asarray(ds_vert['hybm'].max()))
+      p_out_max = hyam_max*p0 + hybm_max*ps_max
       if p_in_max > 0.0 and p_in_max < 1.2e3 and p_out_max > 1.0e4:
         raise ValueError(
           f'source vertical pressure (max {p_in_max:.3g}) and target grid '

--- a/hiccup/hiccup_vertical_remap.py
+++ b/hiccup/hiccup_vertical_remap.py
@@ -49,27 +49,43 @@ def _compute_input_pressure(ds, lev_name, ps):
   """
   return an xarray.DataArray of pressure on the source vertical grid
   detects three layouts:
-    1. EAM / EAMxx hybrid: hyam, hybm, P0 present -> p = hyam*P0 + hybm*ps
+    1. EAM / EAMxx hybrid: hyam, hybm present -> p = hyam*P0 + hybm*ps
+       (P0 defaults to _DEFAULT_P0 when absent - EAM/CAM hyam are unitless
+       fractions, so a missing P0 must NOT silently drop us to the bare-lev
+       fallback, which mixes hPa lev values with a Pa target grid)
     2. ECMWF IFS hybrid:   hyam in Pa, lnsp present (no P0) -> p = hyam + hybm*ps
     3. pure pressure levels: only the lev coord -> p = ds[lev_name]
+       (converted to Pa when the coordinate advertises hPa/millibar units)
   ps must be the resolved surface pressure DataArray (see _resolve_surface_pressure)
   """
   variables = set(ds.variables.keys())
   hybrid = {'hyam','hybm'}.issubset(variables)
 
-  if hybrid and 'P0' in variables:
-    return ds['hyam']*ds['P0'] + ds['hybm']*ps
-
   if hybrid and 'lnsp' in variables:
-    # IFS layout: hyam is already in Pa
+    # IFS layout: hyam is already in Pa, no P0 scaling
     return ds['hyam'] + ds['hybm']*ps
 
+  if hybrid:
+    # EAM / EAMxx hybrid: hyam is a unitless fraction of P0. Default P0 when the
+    # file hasn't had add_reference_pressure() applied yet - otherwise the old
+    # code fell through to the bare-lev fallback below and used the hPa-valued
+    # lev coordinate as if it were Pa, clamping everything below ~10 hPa to a
+    # constant.
+    p0 = ds['P0'] if 'P0' in variables else _DEFAULT_P0
+    return ds['hyam']*p0 + ds['hybm']*ps
+
   if lev_name in ds.coords or lev_name in ds.variables:
-    return ds[lev_name].astype('float64')
+    lev = ds[lev_name].astype('float64')
+    # pressure-level coordinate: normalize hPa/millibar to Pa so it matches the
+    # Pa-valued target grid (p_out = hyam*P0 + hybm*ps)
+    units = str(lev.attrs.get('units','')).strip().lower()
+    if units in ('hpa','mb','millibar','millibars','mbar'):
+      lev = lev*100.0
+    return lev
 
   raise ValueError(
     f'cannot infer source vertical grid for lev_name={lev_name!r}; '
-    f'expected hybrid (hyam,hybm,P0|lnsp) or pressure-level coordinate'
+    f'expected hybrid (hyam,hybm[,P0|lnsp]) or pressure-level coordinate'
   )
 
 # ---------------------------------------------------------------------------
@@ -235,6 +251,23 @@ def remap_vertical_py(input_file, output_file, vert_file,
 
     p_in  = _compute_input_pressure(ds_in, lev_name, ps)
     p_out = _compute_output_pressure(ds_vert, ps, out_lev_name)
+
+    # guard against a source/target vertical-unit mismatch. The classic failure
+    # is a source file whose hybrid coefficients (or P0) went missing, so the
+    # source pressure ends up as a bare hPa lev coordinate (max ~1000) while the
+    # target grid is in Pa (max ~1e5). np.interp would then clamp every level
+    # below ~10 hPa to a constant instead of raising - fail loudly instead.
+    p_in_max  = float(np.asarray(p_in.max()))
+    p_out_max = float(np.asarray(p_out.max()))
+    if p_in_max > 0.0 and p_in_max < 1.2e3 and p_out_max > 1.0e4:
+      raise ValueError(
+        f'source vertical pressure (max {p_in_max:.3g}) and target grid '
+        f'(max {p_out_max:.3g} Pa) appear to be in different units - the source '
+        f'looks like hPa while the target is Pa. This usually means the source '
+        f'file is missing its hybrid coefficients (hyam/hybm/P0) at the vertical '
+        f'remap step, so lev={lev_name!r} was used directly as pressure. '
+        f'Add P0 (add_reference_pressure) or set the lev units to Pa/hPa.'
+      )
 
     # decide which fields get remapped; never remap the hybrid coefficients themselves -
     # those describe the vertical grid and are pulled from vert_file

--- a/test_scripts/unit_test_vertical_remap.py
+++ b/test_scripts/unit_test_vertical_remap.py
@@ -16,7 +16,8 @@ from hiccup.hiccup_vertical_remap import (remap_vertical_py,
                                           _compute_input_pressure,
                                           _compute_output_pressure,
                                           _interp_column,
-                                          _remap_field)
+                                          _remap_field,
+                                          _DEFAULT_P0)
 
 # ---------------------------------------------------------------------------
 # fixture helpers
@@ -208,6 +209,43 @@ class compute_pressure_test_case(unittest.TestCase):
     ])
     np.testing.assert_allclose(p, expected, rtol=1e-12)
     print_timer(timer_start, caller='test_input_pressure_hybrid_eam')
+  # ------------------------------------------------------------------------
+  def test_input_pressure_hybrid_eam_defaults_p0_when_missing(self):
+    """
+    EAM hybrid input with hyam/hybm but NO P0 (file not yet through
+    add_reference_pressure) must still use the hybrid formula with a default P0.
+    Regression: the old code fell through to the bare-lev fallback and used the
+    hPa-valued lev coordinate as Pa, clamping everything below ~10 hPa to a
+    constant (only visibly wrong in T, whose profile has structure aloft).
+    """
+    timer_start = perf_counter()
+    ds = xr.Dataset({
+      'hyam': (('lev',), np.array([0.1, 0.2])),
+      'hybm': (('lev',), np.array([0.0, 0.5])),
+      'PS':   (('ncol',), np.array([1.0e5, 9.5e4])),
+    }, coords={'lev': np.array([100.0, 800.0])})  # hPa-looking lev, must be ignored
+    ps = ds['PS']
+    p = _compute_input_pressure(ds, lev_name='lev', ps=ps).values
+    expected = np.array([
+      [0.1*_DEFAULT_P0 + 0.0*1.0e5, 0.1*_DEFAULT_P0 + 0.0*9.5e4],
+      [0.2*_DEFAULT_P0 + 0.5*1.0e5, 0.2*_DEFAULT_P0 + 0.5*9.5e4],
+    ])
+    np.testing.assert_allclose(p, expected, rtol=1e-12)
+    print_timer(timer_start, caller='test_input_pressure_hybrid_eam_defaults_p0_when_missing')
+  # ------------------------------------------------------------------------
+  def test_input_pressure_pure_pressure_hpa_units_converted(self):
+    """
+    a pressure-level coordinate that advertises hPa/millibar units should be
+    converted to Pa so it matches the Pa-valued target grid
+    """
+    timer_start = perf_counter()
+    plev = np.array([10.0, 100.0, 500.0, 1000.0])  # hPa
+    lev = xr.DataArray(plev, dims='plev'); lev.attrs['units'] = 'hPa'
+    ds = xr.Dataset({'PS': (('ncol',), np.array([1.0e5]))},
+                    coords={'plev': lev})
+    p = _compute_input_pressure(ds, lev_name='plev', ps=ds['PS']).values
+    np.testing.assert_allclose(p, plev*100.0, rtol=1e-12)
+    print_timer(timer_start, caller='test_input_pressure_pure_pressure_hpa_units_converted')
   # ------------------------------------------------------------------------
   def test_input_pressure_hybrid_ifs(self):
     """
@@ -493,6 +531,59 @@ class remap_vertical_end_to_end_test_case(unittest.TestCase):
       self.assertIn('P0', ds_out.variables)
       self.assertEqual(float(ds_out['P0'].values), 1.0e5)
     print_timer(timer_start, caller='test_p0_always_written_even_when_vert_file_lacks_it')
+  # ------------------------------------------------------------------------
+  def test_source_missing_p0_remaps_correctly_not_constant(self):
+    """
+    a hybrid source that still has hyam/hybm but lost P0 must remap to the correct
+    analytic profile - NOT collapse to a constant below ~10 hPa. This is the
+    end-to-end guard for the reported bug where only T looked wrong because the
+    source pressure silently fell back to the hPa lev coordinate.
+    """
+    timer_start = perf_counter()
+    no_p0_src = os.path.join(self.tmpdir, 'src_no_p0.nc')
+    # give lev genuine hPa-looking values so the old fallback would misfire
+    hyam = self.ds_src['hyam'].values
+    hybm = self.ds_src['hybm'].values
+    lev_hpa = (hyam*1.0e5 + hybm*1.0e5)/100.0
+    src = self.ds_src.drop_vars('P0').assign_coords(lev=lev_hpa)
+    src.to_netcdf(no_p0_src)
+    out = os.path.join(self.tmpdir, 'out_no_p0.nc')
+    remap_vertical_py(no_p0_src, out, self.vert_file, ps_name='PS', lev_name='lev')
+    with xr.open_dataset(out) as ds_out:
+      hyam_t = ds_out['hyam'].values
+      hybm_t = ds_out['hybm'].values
+      ps     = ds_out['PS'].values
+      p_tgt  = hyam_t[None, :, None]*1.0e5 + hybm_t[None, :, None]*ps[:, None, :]
+      T_exp  = 250.0 + 30.0*np.log(p_tgt/1.0e5)
+      T_got  = ds_out['T'].transpose('time', 'lev', 'ncol').values
+      np.testing.assert_allclose(T_got, T_exp, rtol=1e-8, atol=1e-8)
+      # and it must not be constant in the vertical
+      self.assertGreater(np.ptp(T_got, axis=1).min(), 1.0)
+    print_timer(timer_start, caller='test_source_missing_p0_remaps_correctly_not_constant')
+  # ------------------------------------------------------------------------
+  def test_hpa_pa_unit_mismatch_raises(self):
+    """
+    a source with no hybrid coefs and a bare hPa lev coordinate (no units attr)
+    remapped onto a Pa target grid should raise a clear ValueError rather than
+    silently clamping everything below ~10 hPa to a constant
+    """
+    timer_start = perf_counter()
+    hpa_src = os.path.join(self.tmpdir, 'src_hpa.nc')
+    lev_hpa = np.linspace(1.0, 1000.0, 20)  # hPa, ascending; no units attribute
+    ntime, ncol = 2, 4
+    T = 250.0 + 30.0*np.log((lev_hpa*100.0)/1.0e5)
+    T = np.broadcast_to(T[None, :, None], (ntime, 20, ncol))
+    ds = xr.Dataset(
+      data_vars={
+        'T':  (('time', 'lev', 'ncol'), T.astype(np.float64)),
+        'PS': (('time', 'ncol'), np.full((ntime, ncol), 1.0e5)),
+      },
+      coords={'time': np.arange(ntime), 'lev': lev_hpa, 'ncol': np.arange(ncol)},
+    )
+    ds.to_netcdf(hpa_src)
+    with self.assertRaises(ValueError):
+      remap_vertical_py(hpa_src, self.out_file, self.vert_file, ps_name='PS', lev_name='lev')
+    print_timer(timer_start, caller='test_hpa_pa_unit_mismatch_raises')
   # ------------------------------------------------------------------------
   def test_var_list_filters_remapped_fields(self):
     """

--- a/test_scripts/unit_test_vertical_remap.py
+++ b/test_scripts/unit_test_vertical_remap.py
@@ -268,6 +268,50 @@ class compute_pressure_test_case(unittest.TestCase):
     np.testing.assert_allclose(p, expected, rtol=1e-12)
     print_timer(timer_start, caller='test_input_pressure_hybrid_ifs')
   # ------------------------------------------------------------------------
+  def test_input_pressure_hybrid_ifs_with_p0_present(self):
+    """
+    an IFS hybrid input (hyam in Pa) that also carries P0 - e.g. after
+    add_reference_pressure - must still use the additive IFS formula
+    p = hyam + hybm*ps and NOT scale hyam by P0
+    """
+    timer_start = perf_counter()
+    hyam_pa = np.array([1.0e3, 2.0e3])
+    ds = xr.Dataset({
+      'hyam': (('lev',), hyam_pa),
+      'hybm': (('lev',), np.array([0.0, 0.5])),
+      'lnsp': (('ncol',), np.log(np.array([1.0e5, 9.5e4]))),
+      'P0':   ((), np.float64(1.0e5)),
+    })
+    ps = _resolve_surface_pressure(ds, 'PS')
+    p = _compute_input_pressure(ds, lev_name='lev', ps=ps).values
+    expected = np.array([
+      [1.0e3 + 0.0*1.0e5, 1.0e3 + 0.0*9.5e4],
+      [2.0e3 + 0.5*1.0e5, 2.0e3 + 0.5*9.5e4],
+    ])
+    np.testing.assert_allclose(p, expected, rtol=1e-12)
+    print_timer(timer_start, caller='test_input_pressure_hybrid_ifs_with_p0_present')
+  # ------------------------------------------------------------------------
+  def test_input_pressure_hybrid_ifs_with_ps_no_lnsp(self):
+    """
+    an IFS hybrid input (hyam in Pa) that supplies PS directly instead of lnsp
+    must be recognized as IFS from the hyam magnitude, not mis-scaled as EAM
+    """
+    timer_start = perf_counter()
+    hyam_pa = np.array([1.0e3, 2.0e3])
+    ds = xr.Dataset({
+      'hyam': (('lev',), hyam_pa),
+      'hybm': (('lev',), np.array([0.0, 0.5])),
+      'PS':   (('ncol',), np.array([1.0e5, 9.5e4])),
+    })
+    ps = _resolve_surface_pressure(ds, 'PS')
+    p = _compute_input_pressure(ds, lev_name='lev', ps=ps).values
+    expected = np.array([
+      [1.0e3 + 0.0*1.0e5, 1.0e3 + 0.0*9.5e4],
+      [2.0e3 + 0.5*1.0e5, 2.0e3 + 0.5*9.5e4],
+    ])
+    np.testing.assert_allclose(p, expected, rtol=1e-12)
+    print_timer(timer_start, caller='test_input_pressure_hybrid_ifs_with_ps_no_lnsp')
+  # ------------------------------------------------------------------------
   def test_input_pressure_pure_pressure_levels(self):
     """
     pure pressure-level input should return the lev coord directly


### PR DESCRIPTION
This pull request improves the robustness and correctness of vertical remapping in the `hiccup_vertical_remap.py` module, especially when handling hybrid vertical coordinates with missing reference pressure (`P0`) and unit mismatches between source and target pressure grids. It also adds comprehensive tests to guard against common pitfalls and regressions.

**Vertical coordinate handling and unit safety:**

* In `_compute_input_pressure`, the logic for EAM/EAMxx hybrid vertical grids now uses a default `_DEFAULT_P0` if `P0` is missing, preventing silent fallback to incorrect pressure calculations using the `lev` coordinate (which could be in hPa). Pressure-level coordinates with hPa/millibar units are now explicitly converted to Pa for consistency.
* In `remap_vertical_py`, a check was added to detect and raise an error when the source and target pressure grids are likely in different units (e.g., source in hPa, target in Pa), preventing silent data corruption during interpolation.

**Testing and regression coverage:**

* New tests in `unit_test_vertical_remap.py` verify that hybrid grids without `P0` use the default value, that pressure-level coordinates in hPa are converted to Pa, and that remapping with missing `P0` produces correct, non-constant results. [[1]](diffhunk://#diff-48838d378198c7058fdfb13259f6a9b0fe59cc8566cf7a6289fb96c550df50f9R213-R249) [[2]](diffhunk://#diff-48838d378198c7058fdfb13259f6a9b0fe59cc8566cf7a6289fb96c550df50f9R535-R587)
* A test ensures that a source file with a bare hPa `lev` coordinate and no hybrid coefficients will raise a clear error if remapped onto a Pa target grid, rather than silently producing incorrect results.
* The test module imports `_DEFAULT_P0` to support the new test cases.